### PR TITLE
Tidy up resources in CF template on which the permissions are applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ var/
 node_modules
 package-lock.json
 .vscode/
+config/
 
 # Sphinx stuff
 _build

--- a/functions/authorizer.py
+++ b/functions/authorizer.py
@@ -5,7 +5,7 @@ import os
 
 REGION = os.getenv('REGION', 'us-west-2')
 ssm = boto3.client('ssm', region_name=REGION)
-service_token = os.getenv('token_param')
+service_token = os.getenv('TOKEN')
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -29,16 +29,6 @@ def lambda_handler(event, context):
                 'body': json.dumps('Bad Request')
         }
 
-    # The below part is specific to Zoom event validation
-    #
-    # request_body = json.loads(aws_event['body'])
-    # if 'event' not in zoom_event or 'payload' not in zoom_event:
-    #     logger.error("AWS event does not contain Zoom event data.")
-    #     return {
-    #         'statusCode': 400,
-    #         'body': json.dumps('Bad Request')
-    #     }
-
     returnDict['summary'] = '{}_event'.format(service)
     returnDict['source'] = 'api_aws_lambda'
     returnDict['category'] = service
@@ -52,6 +42,8 @@ def lambda_handler(event, context):
 
     queueURL = os.getenv('SQS_URL')
     sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
+    logger.info("Event added to the resource queue.")
+
     return {
         'statusCode': 200,
         'body': json.dumps('Event received')

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -19,69 +19,40 @@ def lambda_handler(event, context):
     returnDict = dict()
     returnDict['details'] = {}
 
+    # See if submitted POST body is a valid JSON
     try:
-        zoom_event = json.loads(aws_event['body'])
+        request_body = json.loads(aws_event['body'])
     except Exception as e:
-        logger.error("Cannot parse event: {}, context: {}, exception: ".format(str(aws_event), context.function_name, e))
+        logger.error("Cannot parse event: {}, context: {}, exception: ".format(str(request_body), context.function_name, e))
         return {
                 'statusCode': 400,
                 'body': json.dumps('Bad Request')
         }
 
-    zoom_event = json.loads(aws_event['body'])
-    if 'event' not in zoom_event or 'payload' not in zoom_event:
-        logger.error("AWS event does not contain Zoom event data.")
-        return {
-            'statusCode': 400,
-            'body': json.dumps('Bad Request')
-        }
+    # The below part is specific to Zoom event validation
+    #
+    # request_body = json.loads(aws_event['body'])
+    # if 'event' not in zoom_event or 'payload' not in zoom_event:
+    #     logger.error("AWS event does not contain Zoom event data.")
+    #     return {
+    #         'statusCode': 400,
+    #         'body': json.dumps('Bad Request')
+    #     }
 
-    returnDict['summary'] = zoom_event['event']
+    returnDict['summary'] = '{}_event'.format(service)
     returnDict['source'] = 'api_aws_lambda'
     returnDict['category'] = service
     returnDict['eventsource'] = service + '_api'
-    # This is probably not very generic
-    returnDict['hostname'] = 'marketplace.'+ service + '.us'
+    returnDict['hostname'] = '{}_host'.format(service)
     returnDict['tags'] = service
-    # So is this
-    returnDict['processname'] = service + 'connect'
+    returnDict['processname'] = service
     returnDict['processid'] = 'none'
     returnDict['severity'] = 'INFO'
+    returnDict['details'] = json.loads(aws_event['body'])
 
-    # Parsing / validation from here is a sample only,
-    # based on "meeting.started" Zoom event
-    if 'payload' in zoom_event:
-        if 'account_id' in zoom_event['payload']:
-            returnDict['details']['account_id'] = zoom_event['payload']['account_id']
-        if 'operator' in zoom_event['payload']:
-            returnDict['details']['operator'] = zoom_event['payload']['operator']
-        if 'operator_id' in zoom_event['payload']:
-            returnDict['details']['operator_id'] = zoom_event['payload']['operator_id']
-        if 'object' in zoom_event['payload']:
-            if 'duration' in zoom_event['payload']['object']:
-                returnDict['details']['duration'] = zoom_event['payload']['object']['duration']
-            if 'start_date' in zoom_event['payload']['object']:
-                returnDict['details']['start_date'] = zoom_event['payload']['object']['start_date']
-            if 'timezone' in zoom_event['payload']['object']:
-                returnDict['details']['timezone'] = zoom_event['payload']['object']['timezone']
-            if 'topic' in zoom_event['payload']['object']:
-                returnDict['details']['topic'] = zoom_event['payload']['object']['topic']
-            if 'id' in zoom_event['payload']['object']:
-                returnDict['details']['id'] = zoom_event['payload']['object']['id']
-            if 'uuid' in zoom_event['payload']['object']:
-                returnDict['details']['uuid'] = zoom_event['payload']['object']['uuid']
-            if 'host_id' in zoom_event['payload']['object']:
-                returnDict['details']['host_id'] = zoom_event['payload']['object']['host_id']
-
-        queueURL = os.getenv('SQS_URL')
-        sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
-        return {
-            'statusCode': 200,
-            'body': json.dumps('Event received')
-        }
-    else:
-        # Not the expected event request format
-        return {
-            'statusCode': 400,
-            'body': json.dumps('Bad Request')
-        }
+    queueURL = os.getenv('SQS_URL')
+    sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Event received')
+    }

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -15,15 +15,19 @@ def lambda_handler(event, context):
     # print(json.dumps(event))
     # This parsing can and will be improved in the future
     logger.info("{} service initialized.".format(service))
-    aws_event = event
+    api_event = event
     returnDict = dict()
     returnDict['details'] = {}
 
-    # See if submitted POST body is a valid JSON
+    # See if submitted POST body is a valid JSON and has
+    #  a "payload" since this is common in webhook data
     try:
-        request_body = json.loads(aws_event['body'])
+        json.loads(api_event['body']) and 'payload' in api_event['body']
     except Exception as e:
-        logger.error("Cannot parse event: {}, context: {}, exception: ".format(str(request_body), context.function_name, e))
+        logger.error("Cannot parse API event: {}, context: {}, exception: ".format(
+            str(api_event['body']),
+            context.function_name, e)
+        )
         return {
                 'statusCode': 400,
                 'body': json.dumps('Bad Request')
@@ -38,7 +42,7 @@ def lambda_handler(event, context):
     returnDict['processname'] = service
     returnDict['processid'] = 'none'
     returnDict['severity'] = 'INFO'
-    returnDict['details'] = json.loads(aws_event['body'])
+    returnDict['details'] = json.loads(api_event['body'])
 
     queueURL = os.getenv('SQS_URL')
     sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 REGION = os.getenv('REGION', 'us-west-2')
-service = os.getenv('efServiceName', 'default')
+service = os.getenv('SERVICE', 'default')
 sqs = boto3.client('sqs', region_name=REGION)
 ssm = boto3.client('ssm', region_name=REGION)
 logger = logging.getLogger()
@@ -12,52 +12,66 @@ logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context):
-    # This parsing can and will be improved in another PR
-    if 'requestBody' in event['body']:
-        returnDict = dict()
-        returnDict['details'] = {}
-        event = json.loads(event['body'])
-        event_body = event['requestBody']
-        if 'event' not in event_body or 'payload' not in event_body:
+    # print(json.dumps(event))
+    # This parsing can and will be improved in the future
+    logger.info("{} service initialized.".format(service))
+    aws_event = event
+    returnDict = dict()
+    returnDict['details'] = {}
+
+    try:
+        json.loads(aws_event['body'])
+    except Exception as e:
+        logger.error("Cannot parse event: {}, context: {}, exception: ".format(str(aws_event), context.function_name, e))
+        return {
+                'statusCode': 400,
+                'body': json.dumps('Bad Request')
+        }
+    else:
+        zoom_event = aws_event['body']
+        if 'event' not in zoom_event or 'payload' not in zoom_event:
+            logger.error("AWS event does not contain Zoom event data.")
             return {
                 'statusCode': 400,
                 'body': json.dumps('Bad Request')
             }
 
-        returnDict['summary'] = event_body['event']
+        returnDict['summary'] = zoom_event['event']
         returnDict['source'] = 'api_aws_lambda'
         returnDict['category'] = service
         returnDict['eventsource'] = service + '_api'
+        # This is probably not very generic
         returnDict['hostname'] = 'marketplace.'+ service + '.us'
         returnDict['tags'] = service
+        # So is this
         returnDict['processname'] = service + 'connect'
         returnDict['processid'] = 'none'
         returnDict['severity'] = 'INFO'
 
-        if 'payload' in event_body:
-            if 'account_id' in event_body['payload']:
-                returnDict['details']['account_id'] = event_body['payload']['account_id']
-            if 'operator' in event_body['payload']:
-                returnDict['details']['operator'] = event_body['payload']['operator']
-            if 'operator_id' in event_body['payload']:
-                returnDict['details']['operator_id'] = event_body['payload']['operator_id']
-            if 'object' in event_body['payload']:
-                if 'id' in event_body['payload']['object']:
-                    returnDict['details']['id'] = event_body['payload']['object']['id']
-                if 'owner_id' in event_body['payload']['object']:
-                    returnDict['details']['owner_id'] = event_body['payload']['object']['owner_id']
-                if 'owner_email' in event_body['payload']['object']:
-                    returnDict['details']['owner_email'] = event_body['payload']['object']['owner_email']
+        if 'payload' in zoom_event:
+            if 'account_id' in zoom_event['payload']:
+                returnDict['details']['account_id'] = zoom_event['payload']['account_id']
+            if 'operator' in zoom_event['payload']:
+                returnDict['details']['operator'] = zoom_event['payload']['operator']
+            if 'operator_id' in zoom_event['payload']:
+                returnDict['details']['operator_id'] = zoom_event['payload']['operator_id']
+            if 'object' in zoom_event['payload']:
+                if 'id' in zoom_event['payload']['object']:
+                    returnDict['details']['id'] = zoom_event['payload']['object']['id']
+                if 'owner_id' in zoom_event['payload']['object']:
+                    returnDict['details']['owner_id'] = zoom_event['payload']['object']['owner_id']
+                if 'owner_email' in zoom_event['payload']['object']:
+                    returnDict['details']['owner_email'] = zoom_event['payload']['object']['owner_email']
 
-        queueURL = os.getenv('SQS_URL')   # Obtaining the queue as environment variable
-        sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
-        return {
-            'statusCode': 200,
-            'body': json.dumps('Event received')
-        }
-    else:
-        # Not the expected event request format
-        return {
-            'statusCode': 400,
-            'body': json.dumps('Bad Request')
-        }
+            queueURL = os.getenv('SQS_URL')
+            sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
+            return {
+                'statusCode': 200,
+                'body': json.dumps('Event received')
+            }
+        else:
+            # Not the expected event request format
+            return {
+                'statusCode': 400,
+                'body': json.dumps('Bad Request')
+            }

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -22,12 +22,18 @@ def lambda_handler(event, context):
     # See if submitted POST body is a valid JSON and has
     #  a "payload" since this is common in webhook data
     try:
-        json.loads(api_event['body']) and 'payload' in api_event['body']
+        json.loads(api_event['body'])
     except Exception as e:
         logger.error("Cannot parse API event: {}, context: {}, exception: ".format(
             str(api_event['body']),
             context.function_name, e)
         )
+        return {
+                'statusCode': 400,
+                'body': json.dumps('Bad Request')
+        }
+    if 'payload' not in json.loads(api_event['body']).keys():
+        logger.error("Expecting a payload for the event, but not found.")
         return {
                 'statusCode': 400,
                 'body': json.dumps('Bad Request')

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -20,58 +20,68 @@ def lambda_handler(event, context):
     returnDict['details'] = {}
 
     try:
-        json.loads(aws_event['body'])
+        zoom_event = json.loads(aws_event['body'])
     except Exception as e:
         logger.error("Cannot parse event: {}, context: {}, exception: ".format(str(aws_event), context.function_name, e))
         return {
                 'statusCode': 400,
                 'body': json.dumps('Bad Request')
         }
+
+    zoom_event = json.loads(aws_event['body'])
+    if 'event' not in zoom_event or 'payload' not in zoom_event:
+        logger.error("AWS event does not contain Zoom event data.")
+        return {
+            'statusCode': 400,
+            'body': json.dumps('Bad Request')
+        }
+
+    returnDict['summary'] = zoom_event['event']
+    returnDict['source'] = 'api_aws_lambda'
+    returnDict['category'] = service
+    returnDict['eventsource'] = service + '_api'
+    # This is probably not very generic
+    returnDict['hostname'] = 'marketplace.'+ service + '.us'
+    returnDict['tags'] = service
+    # So is this
+    returnDict['processname'] = service + 'connect'
+    returnDict['processid'] = 'none'
+    returnDict['severity'] = 'INFO'
+
+    # Parsing / validation from here is a sample only,
+    # based on "meeting.started" Zoom event
+    if 'payload' in zoom_event:
+        if 'account_id' in zoom_event['payload']:
+            returnDict['details']['account_id'] = zoom_event['payload']['account_id']
+        if 'operator' in zoom_event['payload']:
+            returnDict['details']['operator'] = zoom_event['payload']['operator']
+        if 'operator_id' in zoom_event['payload']:
+            returnDict['details']['operator_id'] = zoom_event['payload']['operator_id']
+        if 'object' in zoom_event['payload']:
+            if 'duration' in zoom_event['payload']['object']:
+                returnDict['details']['duration'] = zoom_event['payload']['object']['duration']
+            if 'start_date' in zoom_event['payload']['object']:
+                returnDict['details']['start_date'] = zoom_event['payload']['object']['start_date']
+            if 'timezone' in zoom_event['payload']['object']:
+                returnDict['details']['timezone'] = zoom_event['payload']['object']['timezone']
+            if 'topic' in zoom_event['payload']['object']:
+                returnDict['details']['topic'] = zoom_event['payload']['object']['topic']
+            if 'id' in zoom_event['payload']['object']:
+                returnDict['details']['id'] = zoom_event['payload']['object']['id']
+            if 'uuid' in zoom_event['payload']['object']:
+                returnDict['details']['uuid'] = zoom_event['payload']['object']['uuid']
+            if 'host_id' in zoom_event['payload']['object']:
+                returnDict['details']['host_id'] = zoom_event['payload']['object']['host_id']
+
+        queueURL = os.getenv('SQS_URL')
+        sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
+        return {
+            'statusCode': 200,
+            'body': json.dumps('Event received')
+        }
     else:
-        zoom_event = aws_event['body']
-        if 'event' not in zoom_event or 'payload' not in zoom_event:
-            logger.error("AWS event does not contain Zoom event data.")
-            return {
-                'statusCode': 400,
-                'body': json.dumps('Bad Request')
-            }
-
-        returnDict['summary'] = zoom_event['event']
-        returnDict['source'] = 'api_aws_lambda'
-        returnDict['category'] = service
-        returnDict['eventsource'] = service + '_api'
-        # This is probably not very generic
-        returnDict['hostname'] = 'marketplace.'+ service + '.us'
-        returnDict['tags'] = service
-        # So is this
-        returnDict['processname'] = service + 'connect'
-        returnDict['processid'] = 'none'
-        returnDict['severity'] = 'INFO'
-
-        if 'payload' in zoom_event:
-            if 'account_id' in zoom_event['payload']:
-                returnDict['details']['account_id'] = zoom_event['payload']['account_id']
-            if 'operator' in zoom_event['payload']:
-                returnDict['details']['operator'] = zoom_event['payload']['operator']
-            if 'operator_id' in zoom_event['payload']:
-                returnDict['details']['operator_id'] = zoom_event['payload']['operator_id']
-            if 'object' in zoom_event['payload']:
-                if 'id' in zoom_event['payload']['object']:
-                    returnDict['details']['id'] = zoom_event['payload']['object']['id']
-                if 'owner_id' in zoom_event['payload']['object']:
-                    returnDict['details']['owner_id'] = zoom_event['payload']['object']['owner_id']
-                if 'owner_email' in zoom_event['payload']['object']:
-                    returnDict['details']['owner_email'] = zoom_event['payload']['object']['owner_email']
-
-            queueURL = os.getenv('SQS_URL')
-            sqs.send_message(QueueUrl=queueURL, MessageBody=json.dumps(returnDict))
-            return {
-                'statusCode': 200,
-                'body': json.dumps('Event received')
-            }
-        else:
-            # Not the expected event request format
-            return {
-                'statusCode': 400,
-                'body': json.dumps('Bad Request')
-            }
+        # Not the expected event request format
+        return {
+            'statusCode': 400,
+            'body': json.dumps('Bad Request')
+        }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zoom2mozdef-event-framework",
+  "name": "mozdef-event-framework",
   "version": "0.0.1",
   "description": "MozDef event framework PoC using AWS + Serverless framework",
   "main": "index.js",
@@ -8,12 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mozilla/zoom2mozdef-event-framework.git"
+    "url": "git+https://github.com/mozilla/mozdef-event-framework.git"
   },
   "author": "",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/mozilla/zoom2mozdef-event-framework/issues"
+    "url": "https://github.com/mozilla/mozdef-event-framework/issues"
   },
-  "homepage": "https://github.com/mozilla/zoom2mozdef-event-framework#readme"
+  "homepage": "https://github.com/mozilla/mozdef-event-framework#readme",
+  "devDependencies": {
+    "serverless-prune-plugin": "^1.4.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/mozilla/mozdef-event-framework#readme",
   "devDependencies": {
-    "serverless-prune-plugin": "^1.4.1"
+    "serverless-prune-plugin": "^1.4.1",
+    "serverless-pseudo-parameters": "^2.4.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,16 @@
 # This way we would not need a custom vars file for configuration
 
 # Default values for env variables are not supported by serverless
+# Giving example values for each as comment:
+#
+# SERVICE=zoom_event_consumer
+# RESOURCE_NAME=zoom
+# API_PATH=/zoom (or zoom)
+# STAGE=dev
+#
+# With these sample values, the TOKEN value becomes:
+# "/mozdef-event-framework/zoom_event_consumer/dev/zoom/auth_token"
+
 service: ${env:SERVICE}
 plugins:
 # Removing the serverless-stack-output plugin, as I do not think

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ custom:
     resource_name: ${env:RESOURCE_NAME}
     api_method: POST
     api_path: ${env:API_PATH}
-    authToken: ${env:SERVICE}/${env:STAGE}/${env:RESOURCE_NAME}/auth_token
+    authToken: ${env:SERVICE}/${env:STAGE}/auth_token
     project: 'mozdef-event-framework'
 prune:
   automatic: true
@@ -49,8 +49,8 @@ provider:
     lambda: true
   tags:
     Project: ${self:custom.cfg.project}
-  stackName: ${self:custom.cfg.resource_name}-${self:provider.stage}
-  apiName: ${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}
+  stackName: ${self:service}-${self:provider.stage}
+  apiName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -58,7 +58,7 @@ provider:
         - sqs:GetQueueAttributes
         - sqs:ListQueues
       Resource: 
-        - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}"
+        - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.project}-${self:service}-${self:provider.stage}"
     - Effect: Allow
       Action: 
         - ssm:GetParameter
@@ -114,11 +114,11 @@ resources:
     RestApi:
       Type: 'AWS::ApiGateway::RestApi'
       Properties:
-        Name: ${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}-apigw
+        Name: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}-apigw
     ResourceQueue:    
       Type: AWS::SQS::Queue
       Properties:
-        QueueName: ${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}
+        QueueName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}
         MessageRetentionPeriod: 1209600
         VisibilityTimeout: 60
         RedrivePolicy:
@@ -130,5 +130,5 @@ resources:
     DeadLetterQueue:
       Type: AWS::SQS::Queue
       Properties:
-        QueueName: ${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}-DLQ
+        QueueName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}-DLQ
         MessageRetentionPeriod: 1209600

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ plugins:
 # Removing the serverless-stack-output plugin, as I do not think
 # we need it, but I may be wrong
   - serverless-prune-plugin
+  - serverless-pseudo-parameters
 custom:
   authorizer:
     validate_token:
@@ -47,7 +48,7 @@ provider:
         - sqs:GetQueueAttributes
         - sqs:ListQueues
       Resource: 
-        - "arn:aws:sqs:*:*:${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}"
+        - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.resource_name}-${self:custom.cfg.project}-${self:provider.stage}"
     - Effect: Allow
       Action: 
         - ssm:GetParameter

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,13 +5,12 @@
 # Default values for env variables are not supported by serverless
 # Giving example values for each as comment:
 #
-# SERVICE=zoom_event_consumer
-# RESOURCE_NAME=zoom
+# SERVICE=zoom
 # API_PATH=/zoom (or zoom)
 # STAGE=dev
 #
 # With these sample values, the TOKEN value becomes:
-# "/mozdef-event-framework/zoom_event_consumer/dev/zoom/auth_token"
+# "/mozdef-event-framework/zoom/dev/auth_token"
 
 service: ${env:SERVICE}
 plugins:
@@ -29,10 +28,9 @@ custom:
   cfg:
     # Taking some values from build script as environment
     # variables so they remain generic
-    resource_name: ${env:RESOURCE_NAME}
     api_method: POST
     api_path: ${env:API_PATH}
-    authToken: ${env:SERVICE}/${env:STAGE}/auth_token
+    authToken: ${self:service}/${env:STAGE}/auth_token
     project: 'mozdef-event-framework'
 prune:
   automatic: true
@@ -75,9 +73,8 @@ provider:
   # so can refer to them from within code
   environment:
     REGION: '#{AWS::Region}'
-    SERVICE: '${env:SERVICE}'
+    SERVICE: '${self:service}'
     STAGE: '${env:STAGE}'
-    RESOURCE_NAME: '${env:RESOURCE_NAME}'
     TOKEN: "/${self:custom.cfg.project}/${self:custom.cfg.authToken}"
     # Adding resource queue URL as global environment variable
     # We could also store this in SSM
@@ -101,7 +98,7 @@ functions:
     handler: functions/authorizer.validate_token
   event_handler:
     handler: functions/handler.lambda_handler
-    description: Lambda for handling events from ${env:RESOURCE_NAME} resource.
+    description: Lambda for handling events from ${self:service} resource.
     events:
       - http:
           path: ${self:custom.cfg.api_path}

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,6 @@ service: ${env:SERVICE}
 plugins:
 # Removing the serverless-stack-output plugin, as I do not think
 # we need it, but I may be wrong
-  - serverless-pseudo-parameters
   - serverless-prune-plugin
 custom:
   authorizer:

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,12 +5,13 @@
 # Default values for env variables are not supported by serverless
 # Giving example values for each as comment:
 #
-# SERVICE=zoom
+# SERVICE=zoom_event_consumer
+# RESOURCE_NAME=zoom
 # API_PATH=/zoom (or zoom)
 # STAGE=dev
 #
 # With these sample values, the TOKEN value becomes:
-# "/mozdef-event-framework/zoom/dev/auth_token"
+# "/mozdef-event-framework/zoom_event_consumer/dev/zoom/auth_token"
 
 service: ${env:SERVICE}
 plugins:
@@ -28,9 +29,10 @@ custom:
   cfg:
     # Taking some values from build script as environment
     # variables so they remain generic
+    resource_name: ${env:RESOURCE_NAME}
     api_method: POST
     api_path: ${env:API_PATH}
-    authToken: ${self:service}/${env:STAGE}/auth_token
+    authToken: ${env:SERVICE}/${env:STAGE}/auth_token
     project: 'mozdef-event-framework'
 prune:
   automatic: true
@@ -73,8 +75,9 @@ provider:
   # so can refer to them from within code
   environment:
     REGION: '#{AWS::Region}'
-    SERVICE: '${self:service}'
+    SERVICE: '${env:SERVICE}'
     STAGE: '${env:STAGE}'
+    RESOURCE_NAME: '${env:RESOURCE_NAME}'
     TOKEN: "/${self:custom.cfg.project}/${self:custom.cfg.authToken}"
     # Adding resource queue URL as global environment variable
     # We could also store this in SSM
@@ -98,7 +101,7 @@ functions:
     handler: functions/authorizer.validate_token
   event_handler:
     handler: functions/handler.lambda_handler
-    description: Lambda for handling events from ${self:service} resource.
+    description: Lambda for handling events from ${env:RESOURCE_NAME} resource.
     events:
       - http:
           path: ${self:custom.cfg.api_path}

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,9 +32,11 @@ custom:
     api_path: ${env:API_PATH}
     authToken: ${self:service}/${env:STAGE}/auth_token
     project: 'mozdef-event-framework'
-prune:
-  automatic: true
-  number: 5
+    keep: 5
+  # Keeping the last 5 versions of our Lambda functions
+  prune:
+    automatic: true
+    number: ${self:custom.cfg.keep}
 
 provider:
   name: aws

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -374,7 +374,7 @@ Resources:
           - Effect: Allow
             Action:
               - secretsmanager:GetSecretValue
-            Resource: !Join [ '', [ 'arn:aws:secretsmanager:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "secret", ':', !Ref Environment, '/codepipeline/github' ] ]
+            Resource: !Join [ '', [ 'arn:aws:secretsmanager:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "secret", ':', !Ref Environment, '/codepipeline/github*' ] ]
           - Effect: Allow
             Action:
               - codebuild:*

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -198,7 +198,7 @@ Resources:
             - 'cloudformation:DescribeStackResource'
             - 'cloudformation:DescribeStackEvents'
             - 'cloudformation:UpdateStack'
-          Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
+          Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
           Effect: Allow
           Action:
             - 'lambda:AddPermission'
@@ -348,8 +348,8 @@ Resources:
           Resource:
             # NOTE: The below is probably not true. Some permissions
             # require "conditions", and I am not sure how to define them yet.
-            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline ] ]
-            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
+            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline, '/*' ] ]
+            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket, '/*' ] ]
           Effect: Allow
           Action:
             - codecommit:GetBranch
@@ -403,35 +403,60 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Resource: "*"
-            Effect: Allow
+          - Effect: Allow
             Action:
               - s3:PutObject
               - s3:GetObject
               - s3:GetObjectVersion
-              - s3:GetBucketVersioning
-          - Resource: "*"
-            Effect: Allow
+            Resource:
+              # NOTE: The below is probably not true. Some permissions
+              # require "conditions", and I am not sure how to define them yet.
+              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline, '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket, '/*' ] ]
+          - Effect: Allow
             Action:
-              - lambda:*
+              - s3:GetBucketVersioning
+            Resource:
+              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline ] ]
+              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
+          - Effect: Allow
+            Action:
               - codecommit:GetBranch
               - codecommit:GetCommit
               - codecommit:UploadArchive
               - codecommit:GetUploadArchiveStatus
               - codecommit:CancelUploadArchive
+            Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+          - Effect: Allow
+            Action:
               - codebuild:StartBuild
               - codebuild:BatchGetBuilds
-              - cloudformation:*
-              - iam:PassRole
+            Resource: !Join [ '', [ 'arn:aws:codebuild:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':project/', !Ref TestBuildDeploy ] ]
+          - Effect: Allow
+            Action:
               - codepipeline:PutJobSuccessResult
               - codepipeline:PutJobFailureResult
-              - lambda:Listfunctions
-          - Resource: "*"
-            Effect: Allow
+              - lambda:*
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource: 
+              # Also not sure about this one
+              - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodePipelineLambdaRole ] ]
+          - Effect: Allow
+            Action:
+              - cloudformation:*
+            Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
+          - Effect: Allow
             Action:
               - logs:CreateLogGroup
+            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
+          - Effect: Allow
+            Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
+            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
       Roles:
         -  !Ref CodePipelineLambdaRole
   

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -140,7 +140,6 @@ Resources:
         detail-type: 
           - "CodeCommit Repository State Change"
         resources: 
-          # - !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !GetAtt 'CodeCommitRepository.Arn' ] ]
           - !GetAtt 'CodeCommitRepository.Arn'
         detail:
           event:
@@ -211,6 +210,7 @@ Resources:
             Action:
               - 'lambda:AddPermission'
               - 'lambda:CreateAlias'
+              - 'lambda:ListAliases'
               - 'lambda:DeleteFunction'
               - 'lambda:InvokeFunction'
               - 'lambda:PublishVersion'
@@ -239,10 +239,10 @@ Resources:
             # Note: This is still not ideal (giving access to all API
             # gateway resources in a region for a single account), 
             # but I could not find how to restrict it even further
-            # Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis/*" ] ]
             Resource: 
               - !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis*" ] ]
-              - !Join [ '', [ 'arn:aws:apigateway:' , !Ref 'AWS::Region', '::', '/tags/arn:aws:apigateway/', !Ref 'AWS::Region', '::', "/restapis/*/stages/", !Ref Environment ]
+              # This is ugly but URL-encoding seems to be required for this
+              - !Join [ '', [ 'arn:aws:apigateway:' , !Ref 'AWS::Region', '::', '/tags/arn%3Aaws%3Aapigateway%3A', !Ref 'AWS::Region', '%3A%3A%2F', "restapis%2F*" ] ]
           - Effect: Allow
             Action:
               - 's3:CreateBucket'

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -222,7 +222,7 @@ Resources:
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
-              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*-" ] ]
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "-*" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
           - Effect: Allow
@@ -458,13 +458,6 @@ Resources:
               - 'cloudformation:DescribeStackResource'
               - 'cloudformation:DescribeStackEvents'
               - 'cloudformation:UpdateStack'
-              - 'cloudformation:ListStacks'
-              - 'cloudformation:GetTemplateSummary'
-              - 'cloudformation:PreviewStackUpdate'
-              - 'cloudformation:ValidateTemplate'
-              - 'cloudformation:CreateUploadBucket'
-              - 'cloudformation:DescribeAccountLimits'
-              - 'cloudformation:DescribeChangeSet'
             Resource: 
               - !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
           - Effect: Allow
@@ -472,6 +465,12 @@ Resources:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
+              - 'cloudformation:ListStacks'
+              - 'cloudformation:GetTemplateSummary'
+              - 'cloudformation:ValidateTemplate'
+              - 'cloudformation:CreateUploadBucket'
+              - 'cloudformation:DescribeAccountLimits'
+              - 'cloudformation:DescribeChangeSet'
             Resource: "*"
       Roles:
         -  !Ref CodePipelineLambdaRole

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -99,6 +99,7 @@ Resources:
     Properties:
       RoleName:
         'Fn::Join': [ "", ["CloudWatchCodeCommitEventRole", "-", !Ref 'AWS::StackName', "-", !Ref 'Environment']]
+      # I think this is OK
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -113,6 +114,7 @@ Resources:
     Properties:
       PolicyName:
         'Fn::Join': [ "", ["CloudwatchCodeCommitEventPolicy", "-", !Ref 'AWS::StackName', "-", !Ref 'Environment']]
+      # This is already restricted
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -166,49 +168,69 @@ Resources:
     Properties:
       PolicyName:
         'Fn::Join': [ "", ["CodeBuildPolicy", "-", !Ref 'AWS::StackName', "-", !Ref 'Environment']]
+      # This is one of the most tricky ones, we may have
+      # to break the permissions down per resource
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
           Effect: Allow
           Action:
-            - 'logs:CreateLogGroup'
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            - 'logs:DescribeLogGroups'
-            - 'logs:FilterLogEvents'
-            - 'logs:DescribeLogStreams'
-            - 'logs:DeleteLogGroup'
             - 'codebuild:*'
+          Resource: !Join [ '', [ 'arn:aws:codebuild:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "project/", !Ref TestBuildDeploy ] ]
+          Effect: Allow
+          Action:
             - 'codecommit:GetBranch'
             - 'codecommit:GetCommit'
             - 'codecommit:UploadArchive'
             - 'codecommit:GetUploadArchiveStatus'
             - 'codecommit:CancelUploadArchive'
-            - 'cloudformation:List*'
-            - 'cloudformation:Get*'
-            - 'cloudformation:PreviewStackUpdate'
-            - 'cloudformation:ValidateTemplate'
+          Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+          Effect: Allow
+          Action:
+            - 'cloudformation:ListChangeSets'
+            - 'cloudformation:ListStackResources'
+            - 'cloudformation:GetStackPolicy'
+            - 'cloudformation:GetTemplate'
             - 'cloudformation:CreateStack'
-            - 'cloudformation:CreateUploadBucket'
             - 'cloudformation:DeleteStack'
-            - 'cloudformation:Describe*'
+            - 'cloudformation:DescribeStacks'
+            - 'cloudformation:DescribeStackResources'
+            - 'cloudformation:DescribeStackResource'
+            - 'cloudformation:DescribeStackEvents'
             - 'cloudformation:UpdateStack'
-            - 'lambda:Get*'
-            - 'lambda:List*'
-            - 'lambda:CreateFunction'
+          Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
+          Effect: Allow
+          Action:
             - 'lambda:AddPermission'
             - 'lambda:CreateAlias'
             - 'lambda:DeleteFunction'
             - 'lambda:InvokeFunction'
             - 'lambda:PublishVersion'
             - 'lambda:RemovePermission'
-            - 'lambda:Update*'
-            - 'lambda:PublishLayerVersion'
+            - 'lambda:UpdateAlias'
+            - 'lambda:UpdateFunctionCode'
+            - 'lambda:UpdateFunctionConfiguration'
+          Resource:
+            # Giving permissions on the lambda functions created 
+            # by the serverless framework, based on the assumption
+            # that serverless frameworks creates function names
+            # based on service name and stage
+            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
+            # Our merger lambda function
+            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref MergeLambda ] ]
+          Effect: Allow
+          Action:
             - 'apigateway:GET'
             - 'apigateway:POST'
             - 'apigateway:PUT'
             - 'apigateway:DELETE'
             - 'apigateway:PATCH'
+          # Note: This is still not ideal (giving access to all API
+          # gateway resources in a region for a single account), 
+          # but I could not find how to restrict it even further
+          Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "/restapis/*" ] ]
+          Effect: Allow
+          Action:
             - 's3:CreateBucket'
             - 's3:DeleteBucket'
             - 's3:ListBucket'
@@ -218,25 +240,73 @@ Resources:
             - 's3:DeleteObject'
             - 's3:PutEncryptionConfiguration'
             - 's3:GetEncryptionConfiguration'
+          # NOTE: The below is probably not true. Some permissions
+          # require "conditions", and I am not sure how to define them yet.
+          Resource: 
+            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline ] ]
+            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
+          Effect: Allow
+          Action:
             - 'iam:PassRole'
-            - 'kinesis:*'
             - 'iam:GetRole'
             - 'iam:CreateRole'
             - 'iam:PutRolePolicy'
             - 'iam:DeleteRolePolicy'
             - 'iam:DeleteRole'
-            - 'cloudwatch:GetMetricStatistics'
-            - 'events:Put*'
-            - 'events:Remove*'
-            - 'events:Delete*'
+          # Also not sure about this one
+          Resource: !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
+          Effect: Allow
+          Action:
+            - 'events:RemoveTargets'
+            - 'events:DeleteRule'
+          Resource: !Join [ '', [ 'arn', !Ref 'AWS::Partition', ':events:', !Ref 'AWS::Region', ':' !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCodeCommitEventRule ] ]
+          Effect: Allow
+          Action:
             - 'ssm:PutParameter'
             - 'ssm:GetParameter'
             - 'ssm:GetParametersByPath'
+          Resource: !Join [ '', [ 'arn:aws:ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':parameter/*' ] ]
+          Effect: Allow
+          Action:
             - 'ssm:AddTagsToResource'
+          Resource: !Join [ '', [ 'arn:aws:ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':document/*' ] ]
+          Effect: Allow
+          Action:
             - 'sqs:CreateQueue'
             - 'sqs:SendMessage'
             - 'sqs:GetQueueAttributes'
             - 'sqs:ListQueues'
+          Resource: !Join [ '', [ 'arn:aws:sqs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':*' ] ]
+          Effect: Allow
+          Action:
+            - 'logs:CreateLogGroup'
+            - 'logs:DeleteLogGroup'
+            - 'logs:DescribeLogGroups'
+            - 'logs:FilterLogEvents'
+          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
+          Effect: Allow
+          Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            - 'logs:DescribeLogStreams'
+          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
+          # Seems like there are some permissions that are 
+          # only applicable to "*" resource, maybe
+          Effect: Allow
+          Action:
+            - 'cloudformation:ListStacks'
+            - 'cloudformation:GetTemplateSummary'
+            - 'cloudformation:PreviewStackUpdate'
+            - 'cloudformation:ValidateTemplate'
+            - 'cloudformation:CreateUploadBucket'
+            - 'cloudformation:DescribeAccountLimits'
+            - 'cloudformation:DescribeChangeSet'
+            - 'lambda:CreateFunction'
+            - 'lambda:PublishLayerVersion'
+            - 'cloudwatch:GetMetricStatistics'
+            - 'events:PutEvents'
+            - 'events:PutRule'
+            - 'events:PutTargets'
           Resource: "*"
       Roles:
         -  !Ref CodeBuildRole

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -125,9 +125,9 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: Allow
-          Action: codepipeline:StartPipelineExecution
-          Resource: !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline] ]
+          - Effect: Allow
+            Action: codepipeline:StartPipelineExecution
+            Resource: !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline] ]
       Roles:
         - !Ref CloudWatchCodeCommitEventRole
 
@@ -180,145 +180,145 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: Allow
-          Action:
-            - 'codebuild:*'
-          Resource: !GetAtt TestBuildDeploy.Arn
-          Effect: Allow
-          Action:
-            - 'codecommit:GetBranch'
-            - 'codecommit:GetCommit'
-            - 'codecommit:UploadArchive'
-            - 'codecommit:GetUploadArchiveStatus'
-            - 'codecommit:CancelUploadArchive'
-          Resource: !GetAtt 'CodeCommitRepository.Arn'
-          Effect: Allow
-          Action:
-            - 'cloudformation:ListChangeSets'
-            - 'cloudformation:ListStackResources'
-            - 'cloudformation:GetStackPolicy'
-            - 'cloudformation:GetTemplate'
-            - 'cloudformation:CreateStack'
-            - 'cloudformation:DeleteStack'
-            - 'cloudformation:DescribeStacks'
-            - 'cloudformation:DescribeStackResources'
-            - 'cloudformation:DescribeStackResource'
-            - 'cloudformation:DescribeStackEvents'
-            - 'cloudformation:UpdateStack'
-          Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
-          Effect: Allow
-          Action:
-            - 'lambda:AddPermission'
-            - 'lambda:CreateAlias'
-            - 'lambda:DeleteFunction'
-            - 'lambda:InvokeFunction'
-            - 'lambda:PublishVersion'
-            - 'lambda:RemovePermission'
-            - 'lambda:UpdateAlias'
-            - 'lambda:UpdateFunctionCode'
-            - 'lambda:UpdateFunctionConfiguration'
-          Resource:
-            # Giving permissions on the lambda functions created 
-            # by the serverless framework, based on the assumption
-            # that serverless frameworks creates function names
-            # based on service name and stage
-            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
-            # Our merger lambda function
-            - !GetAtt MergeLambda.Arn
-          Effect: Allow
-          Action:
-            - 'apigateway:GET'
-            - 'apigateway:POST'
-            - 'apigateway:PUT'
-            - 'apigateway:DELETE'
-            - 'apigateway:PATCH'
-          # Note: This is still not ideal (giving access to all API
-          # gateway resources in a region for a single account), 
-          # but I could not find how to restrict it even further
-          Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "/restapis/*" ] ]
-          Effect: Allow
-          Action:
-            - 's3:CreateBucket'
-            - 's3:DeleteBucket'
-            - 's3:ListBucket'
-            - 's3:ListBucketVersions'
-            - 's3:PutObject'
-            - 's3:GetObject'
-            - 's3:DeleteObject'
-            - 's3:PutEncryptionConfiguration'
-            - 's3:GetEncryptionConfiguration'
-          # NOTE: The below is probably not true. Some permissions
-          # require "conditions", and I am not sure how to define them yet.
-          Resource: 
-            - !GetAtt S3CodePipeline.Arn
-            - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
-            - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
-            - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
-          Effect: Allow
-          Action:
-            - 'iam:PassRole'
-            - 'iam:GetRole'
-            - 'iam:CreateRole'
-            - 'iam:PutRolePolicy'
-            - 'iam:DeleteRolePolicy'
-            - 'iam:DeleteRole'
-          # Also not sure about this one
-          Resource: 
-            # - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
-            - !GetAtt CodeBuildRole.Arn
-          Effect: Allow
-          Action:
-            - 'events:RemoveTargets'
-            - 'events:DeleteRule'
-          Resource: !Join [ '', [ 'arn', !Ref 'AWS::Partition', ':events:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCodeCommitEventRule ] ]
-          Effect: Allow
-          Action:
-            - 'ssm:PutParameter'
-            - 'ssm:GetParameter'
-            - 'ssm:GetParametersByPath'
-          Resource: !Join [ '', [ 'arn:aws:ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':parameter/*' ] ]
-          Effect: Allow
-          Action:
-            - 'ssm:AddTagsToResource'
-          Resource: !Join [ '', [ 'arn:aws:ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':document/*' ] ]
-          Effect: Allow
-          Action:
-            - 'sqs:CreateQueue'
-            - 'sqs:SendMessage'
-            - 'sqs:GetQueueAttributes'
-            - 'sqs:ListQueues'
-          Resource: !Join [ '', [ 'arn:aws:sqs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':*' ] ]
-          Effect: Allow
-          Action:
-            - 'logs:CreateLogGroup'
-            - 'logs:DeleteLogGroup'
-            - 'logs:DescribeLogGroups'
-            - 'logs:FilterLogEvents'
-          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
-          Effect: Allow
-          Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            - 'logs:DescribeLogStreams'
-          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
-          # Seems like there are some permissions that are 
-          # only applicable to "*" resource, maybe
-          Effect: Allow
-          Action:
-            - 'cloudformation:ListStacks'
-            - 'cloudformation:GetTemplateSummary'
-            - 'cloudformation:PreviewStackUpdate'
-            - 'cloudformation:ValidateTemplate'
-            - 'cloudformation:CreateUploadBucket'
-            - 'cloudformation:DescribeAccountLimits'
-            - 'cloudformation:DescribeChangeSet'
-            - 'lambda:CreateFunction'
-            - 'lambda:PublishLayerVersion'
-            - 'cloudwatch:GetMetricStatistics'
-            - 'events:PutEvents'
-            - 'events:PutRule'
-            - 'events:PutTargets'
-          Resource: "*"
+          - Effect: Allow
+            Action:
+              - 'codebuild:*'
+            Resource: !GetAtt TestBuildDeploy.Arn
+          - Effect: Allow
+            Action:
+              - 'codecommit:GetBranch'
+              - 'codecommit:GetCommit'
+              - 'codecommit:UploadArchive'
+              - 'codecommit:GetUploadArchiveStatus'
+              - 'codecommit:CancelUploadArchive'
+            Resource: !GetAtt 'CodeCommitRepository.Arn'
+          - Effect: Allow
+            Action:
+              - 'cloudformation:ListChangeSets'
+              - 'cloudformation:ListStackResources'
+              - 'cloudformation:GetStackPolicy'
+              - 'cloudformation:GetTemplate'
+              - 'cloudformation:CreateStack'
+              - 'cloudformation:DeleteStack'
+              - 'cloudformation:DescribeStacks'
+              - 'cloudformation:DescribeStackResources'
+              - 'cloudformation:DescribeStackResource'
+              - 'cloudformation:DescribeStackEvents'
+              - 'cloudformation:UpdateStack'
+            Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
+          - Effect: Allow
+            Action:
+              - 'lambda:AddPermission'
+              - 'lambda:CreateAlias'
+              - 'lambda:DeleteFunction'
+              - 'lambda:InvokeFunction'
+              - 'lambda:PublishVersion'
+              - 'lambda:RemovePermission'
+              - 'lambda:UpdateAlias'
+              - 'lambda:UpdateFunctionCode'
+              - 'lambda:UpdateFunctionConfiguration'
+            Resource:
+              # Giving permissions on the lambda functions created 
+              # by the serverless framework, based on the assumption
+              # that serverless frameworks creates function names
+              # based on service name and stage
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
+              # Our merger lambda function
+              - !GetAtt MergeLambda.Arn
+          - Effect: Allow
+            Action:
+              - 'apigateway:GET'
+              - 'apigateway:POST'
+              - 'apigateway:PUT'
+              - 'apigateway:DELETE'
+              - 'apigateway:PATCH'
+            # Note: This is still not ideal (giving access to all API
+            # gateway resources in a region for a single account), 
+            # but I could not find how to restrict it even further
+            Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "/restapis/*" ] ]
+          - Effect: Allow
+            Action:
+              - 's3:CreateBucket'
+              - 's3:DeleteBucket'
+              - 's3:ListBucket'
+              - 's3:ListBucketVersions'
+              - 's3:PutObject'
+              - 's3:GetObject'
+              - 's3:DeleteObject'
+              - 's3:PutEncryptionConfiguration'
+              - 's3:GetEncryptionConfiguration'
+            # NOTE: The below is probably not true. Some permissions
+            # require "conditions", and I am not sure how to define them yet.
+            Resource: 
+              - !GetAtt S3CodePipeline.Arn
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
+              - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
+          - Effect: Allow
+            Action:
+              - 'iam:PassRole'
+              - 'iam:GetRole'
+              - 'iam:CreateRole'
+              - 'iam:PutRolePolicy'
+              - 'iam:DeleteRolePolicy'
+              - 'iam:DeleteRole'
+            # Also not sure about this one
+            Resource: 
+              # - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
+              - !GetAtt CodeBuildRole.Arn
+          - Effect: Allow
+            Action:
+              - 'events:RemoveTargets'
+              - 'events:DeleteRule'
+            Resource: !Join [ '', [ 'arn', !Ref 'AWS::Partition', ':events:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCodeCommitEventRule ] ]
+          - Effect: Allow
+            Action:
+              - 'ssm:PutParameter'
+              - 'ssm:GetParameter'
+              - 'ssm:GetParametersByPath'
+            Resource: !Join [ '', [ 'arn:aws:ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':parameter/*' ] ]
+          - Effect: Allow
+            Action:
+              - 'ssm:AddTagsToResource'
+            Resource: !Join [ '', [ 'arn:aws:ssm:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':document/*' ] ]
+          - Effect: Allow
+            Action:
+              - 'sqs:CreateQueue'
+              - 'sqs:SendMessage'
+              - 'sqs:GetQueueAttributes'
+              - 'sqs:ListQueues'
+            Resource: !Join [ '', [ 'arn:aws:sqs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':*' ] ]
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:DeleteLogGroup'
+              - 'logs:DescribeLogGroups'
+              - 'logs:FilterLogEvents'
+            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'logs:DescribeLogStreams'
+            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
+            # Seems like there are some permissions that are 
+            # only applicable to "*" resource, maybe
+          - Effect: Allow
+            Action:
+              - 'cloudformation:ListStacks'
+              - 'cloudformation:GetTemplateSummary'
+              - 'cloudformation:PreviewStackUpdate'
+              - 'cloudformation:ValidateTemplate'
+              - 'cloudformation:CreateUploadBucket'
+              - 'cloudformation:DescribeAccountLimits'
+              - 'cloudformation:DescribeChangeSet'
+              - 'lambda:CreateFunction'
+              - 'lambda:PublishLayerVersion'
+              - 'cloudwatch:GetMetricStatistics'
+              - 'events:PutEvents'
+              - 'events:PutRule'
+              - 'events:PutTargets'
+            Resource: "*"
       Roles:
         -  !Ref CodeBuildRole
 
@@ -343,52 +343,52 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: Allow
-          Action:
-            - logs:CreateLogGroup
-          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
-          Effect: Allow
-          Action:
-            - logs:CreateLogStream
-            - logs:PutLogEvents
-          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
-          Effect: Allow
-          Action:
-            - s3:putObject
-            - s3:getObject
-          Resource:
-            # NOTE: The below is probably not true. Some permissions
-            # require "conditions", and I am not sure how to define them yet.
-            - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
-            - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
-          Effect: Allow
-          Action:
-            - codecommit:GetBranch
-            - codecommit:GetCommit
-            - codecommit:UploadArchive
-            - codecommit:GetUploadArchiveStatus
-            - codecommit:CancelUploadArchive
-          Resource: !GetAtt CodeCommitRepository.Arn
-          Effect: Allow
-          Action:
-            - lambda:InvokeFunction
-          Resource:
-            # Giving permissions on the lambda functions created 
-            # by the serverless framework, based on the assumption
-            # that serverless frameworks creates function names
-            # based on service name and stage
-            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
-            # Our merger lambda function
-            - !GetAtt MergeLambda.Arn
-          Effect: Allow
-          Action:
-            - secretsmanager:GetSecretValue
-          Resource: !Join [ '', [ 'arn:aws:secretsmanager:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "secret", ':', !Ref Environment, '/codepipeline/github' ] ]
-    
-          Effect: Allow
-          Action:
-            - codebuild:*
-          Resource: !GetAtt TestBuildDeploy.Arn
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
+          - Effect: Allow
+            Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
+          - Effect: Allow
+            Action:
+              - s3:putObject
+              - s3:getObject
+            Resource:
+              # NOTE: The below is probably not true. Some permissions
+              # require "conditions", and I am not sure how to define them yet.
+              - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
+          - Effect: Allow
+            Action:
+              - codecommit:GetBranch
+              - codecommit:GetCommit
+              - codecommit:UploadArchive
+              - codecommit:GetUploadArchiveStatus
+              - codecommit:CancelUploadArchive
+            # Resource: !GetAtt CodeCommitRepository.Arn
+            Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource:
+              # Giving permissions on the lambda functions created 
+              # by the serverless framework, based on the assumption
+              # that serverless frameworks creates function names
+              # based on service name and stage
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
+              # Our merger lambda function
+              - !GetAtt MergeLambda.Arn
+          - Effect: Allow
+            Action:
+              - secretsmanager:GetSecretValue
+            Resource: !Join [ '', [ 'arn:aws:secretsmanager:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "secret", ':', !Ref Environment, '/codepipeline/github' ] ]
+          - Effect: Allow
+            Action:
+              - codebuild:*
+            Resource: !GetAtt TestBuildDeploy.Arn
       Roles:
         -  !Ref CodePipelineRole
   

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -240,7 +240,9 @@ Resources:
             # gateway resources in a region for a single account), 
             # but I could not find how to restrict it even further
             # Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis/*" ] ]
-            Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis*" ] ]
+            Resource: 
+              - !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis*" ] ]
+              - !Join [ '', [ 'arn:aws:apigateway:' , !Ref 'AWS::Region', '::', '/tags/arn:aws:apigateway/', !Ref 'AWS::Region', '::', "/restapis/*/stages/", !Ref Environment ]
           - Effect: Allow
             Action:
               - 's3:CreateBucket'

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -57,7 +57,7 @@ Parameters:
   GitHubRepository:
     Type: String
     # Defaulting to our public PoC repo
-    Default: mozilla/mozdef-event-framework-template/master
+    Default: mozilla/mozdef-event-framework/master
     Description:  Github repository to be used as a source, in the form of "owner/repository/branch".
 
   ConfigDirectory:

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -218,13 +218,13 @@ Resources:
               - 'lambda:UpdateAlias'
               - 'lambda:UpdateFunctionCode'
               - 'lambda:UpdateFunctionConfiguration'
+              - 'lambda:GetFunction'
             Resource:
               # Giving permissions on the lambda functions created 
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
-              # TODO: Remove the dash before the star in the end
-              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "-*" ] ]
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
           - Effect: Allow
@@ -270,7 +270,7 @@ Resources:
               - 'iam:DeleteRole'
             # Also not sure about this one
             Resource: 
-              - !Join [ '', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':role/', !Ref Service, '-', !Ref Environment, '-', !Ref 'AWS::Region', '-*' ] ]
+              - !Join [ '', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':role/', !Ref Service, '-', !Ref Environment, '-', !Ref 'AWS::Region', '*' ] ]
               - !GetAtt CodeBuildRole.Arn
           - Effect: Allow
             Action:
@@ -373,7 +373,7 @@ Resources:
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
-              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "-*" ] ]
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
           - Effect: Allow

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -127,7 +127,7 @@ Resources:
         Statement:
           Effect: Allow
           Action: codepipeline:StartPipelineExecution
-          Resource: !GetAtt Pipeline.Arn
+          Resource: !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline] ]
       Roles:
         - !Ref CloudWatchCodeCommitEventRole
 
@@ -152,7 +152,7 @@ Resources:
             - !Ref CodeCommitRepositoryBranch
       Targets:
         -
-          Arn: !GetAtt Pipeline.Arn
+          Arn: !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline] ]
           RoleArn: !GetAtt 'CloudWatchCodeCommitEventRole.Arn'
           Id: !Ref Pipeline
 
@@ -251,7 +251,9 @@ Resources:
           # require "conditions", and I am not sure how to define them yet.
           Resource: 
             - !GetAtt S3CodePipeline.Arn
-            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
+            - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
+            - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
+            - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
           Effect: Allow
           Action:
             - 'iam:PassRole'
@@ -268,7 +270,7 @@ Resources:
           Action:
             - 'events:RemoveTargets'
             - 'events:DeleteRule'
-          Resource: !Join [ '', [ 'arn', !Ref 'AWS::Partition', ':events:', !Ref 'AWS::Region', ':' !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCodeCommitEventRule ] ]
+          Resource: !Join [ '', [ 'arn', !Ref 'AWS::Partition', ':events:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCodeCommitEventRule ] ]
           Effect: Allow
           Action:
             - 'ssm:PutParameter'
@@ -358,7 +360,7 @@ Resources:
             # NOTE: The below is probably not true. Some permissions
             # require "conditions", and I am not sure how to define them yet.
             - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
-            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket, '/*' ] ]
+            - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
           Effect: Allow
           Action:
             - codecommit:GetBranch
@@ -421,13 +423,13 @@ Resources:
               # NOTE: The below is probably not true. Some permissions
               # require "conditions", and I am not sure how to define them yet.
               - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
-              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket, '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
           - Effect: Allow
             Action:
               - s3:GetBucketVersioning
             Resource:
               - !GetAtt S3CodePipeline.Arn
-              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
           - Effect: Allow
             Action:
               - codecommit:GetBranch

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -253,8 +253,10 @@ Resources:
             Resource: 
               - !GetAtt S3CodePipeline.Arn
               - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket' ] ]
               - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
               - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket', '/*' ] ]
           - Effect: Allow
             Action:
               - 'iam:PassRole'

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -52,7 +52,6 @@ Parameters:
     Default: master
     ConstraintDescription: "Can contain only ASCII characters."
   
-  # The below is required to create a Github webhook via CloudFormation
   # Removed personal access token parameter as it is accessed from 
   # AWS Secrets Manager
   GitHubRepository:
@@ -128,7 +127,7 @@ Resources:
         Statement:
           Effect: Allow
           Action: codepipeline:StartPipelineExecution
-          Resource: !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline] ]
+          Resource: !GetAtt Pipeline.Arn
       Roles:
         - !Ref CloudWatchCodeCommitEventRole
 
@@ -141,7 +140,8 @@ Resources:
         detail-type: 
           - "CodeCommit Repository State Change"
         resources: 
-          - !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !GetAtt 'CodeCommitRepository.Arn' ] ] 
+          # - !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !GetAtt 'CodeCommitRepository.Arn' ] ]
+          - !GetAtt 'CodeCommitRepository.Arn'
         detail:
           event:
             - referenceCreated
@@ -152,8 +152,7 @@ Resources:
             - !Ref CodeCommitRepositoryBranch
       Targets:
         -
-          Arn: 
-            !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline] ]
+          Arn: !GetAtt Pipeline.Arn
           RoleArn: !GetAtt 'CloudWatchCodeCommitEventRole.Arn'
           Id: !Ref Pipeline
 
@@ -184,7 +183,7 @@ Resources:
           Effect: Allow
           Action:
             - 'codebuild:*'
-          Resource: !Join [ '', [ 'arn:aws:codebuild:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "project/", !Ref TestBuildDeploy ] ]
+          Resource: !GetAtt TestBuildDeploy.Arn
           Effect: Allow
           Action:
             - 'codecommit:GetBranch'
@@ -192,7 +191,7 @@ Resources:
             - 'codecommit:UploadArchive'
             - 'codecommit:GetUploadArchiveStatus'
             - 'codecommit:CancelUploadArchive'
-          Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+          Resource: !GetAtt 'CodeCommitRepository.Arn'
           Effect: Allow
           Action:
             - 'cloudformation:ListChangeSets'
@@ -225,7 +224,7 @@ Resources:
             # based on service name and stage
             - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
             # Our merger lambda function
-            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref MergeLambda ] ]
+            - !GetAtt MergeLambda.Arn
           Effect: Allow
           Action:
             - 'apigateway:GET'
@@ -251,7 +250,7 @@ Resources:
           # NOTE: The below is probably not true. Some permissions
           # require "conditions", and I am not sure how to define them yet.
           Resource: 
-            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline ] ]
+            - !GetAtt S3CodePipeline.Arn
             - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
           Effect: Allow
           Action:
@@ -262,7 +261,9 @@ Resources:
             - 'iam:DeleteRolePolicy'
             - 'iam:DeleteRole'
           # Also not sure about this one
-          Resource: !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
+          Resource: 
+            # - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
+            - !GetAtt CodeBuildRole.Arn
           Effect: Allow
           Action:
             - 'events:RemoveTargets'
@@ -356,7 +357,7 @@ Resources:
           Resource:
             # NOTE: The below is probably not true. Some permissions
             # require "conditions", and I am not sure how to define them yet.
-            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline, '/*' ] ]
+            - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
             - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket, '/*' ] ]
           Effect: Allow
           Action:
@@ -365,7 +366,7 @@ Resources:
             - codecommit:UploadArchive
             - codecommit:GetUploadArchiveStatus
             - codecommit:CancelUploadArchive
-          Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+          Resource: !GetAtt CodeCommitRepository.Arn
           Effect: Allow
           Action:
             - lambda:InvokeFunction
@@ -376,7 +377,7 @@ Resources:
             # based on service name and stage
             - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
             # Our merger lambda function
-            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref MergeLambda ] ]
+            - !GetAtt MergeLambda.Arn
           Effect: Allow
           Action:
             - secretsmanager:GetSecretValue
@@ -385,7 +386,7 @@ Resources:
           Effect: Allow
           Action:
             - codebuild:*
-          Resource: !Join [ '', [ 'arn:aws:codebuild:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "project/", !Ref TestBuildDeploy ] ]
+          Resource: !GetAtt TestBuildDeploy.Arn
       Roles:
         -  !Ref CodePipelineRole
   
@@ -419,13 +420,13 @@ Resources:
             Resource:
               # NOTE: The below is probably not true. Some permissions
               # require "conditions", and I am not sure how to define them yet.
-              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline, '/*' ] ]
+              - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
               - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket, '/*' ] ]
           - Effect: Allow
             Action:
               - s3:GetBucketVersioning
             Resource:
-              - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline ] ]
+              - !GetAtt S3CodePipeline.Arn
               - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
           - Effect: Allow
             Action:
@@ -434,12 +435,12 @@ Resources:
               - codecommit:UploadArchive
               - codecommit:GetUploadArchiveStatus
               - codecommit:CancelUploadArchive
-            Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+            Resource: !GetAtt CodeCommitRepository.Arn
           - Effect: Allow
             Action:
               - codebuild:StartBuild
               - codebuild:BatchGetBuilds
-            Resource: !Join [ '', [ 'arn:aws:codebuild:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':project/', !Ref TestBuildDeploy ] ]
+            Resource: !GetAtt TestBuildDeploy.Arn
           - Effect: Allow
             Action:
               - codepipeline:PutJobSuccessResult
@@ -451,7 +452,8 @@ Resources:
               - iam:PassRole
             Resource: 
               # Also not sure about this one
-              - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodePipelineLambdaRole ] ]
+              # - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodePipelineLambdaRole ] ]
+              - !GetAtt CodePipelineLambdaRole.Arn
           - Effect: Allow
             Action:
               - cloudformation:*
@@ -515,7 +517,7 @@ Resources:
         Location: !Ref S3CodePipeline
         Type: S3
       RestartExecutionOnUpdate: true
-      RoleArn: !Join [ "", ["arn:aws:iam::", !Ref "AWS::AccountId", ":role/", !Ref CodePipelineRole  ] ]
+      RoleArn: !GetAtt CodePipelineRole.Arn
       Stages:
 
         # Stage 1:  Get the source from CodeCommit, and then from the Github repo

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -223,6 +223,7 @@ Resources:
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
+              # TODO: Remove the dash before the star in the end
               - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "-*" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
@@ -236,7 +237,8 @@ Resources:
             # Note: This is still not ideal (giving access to all API
             # gateway resources in a region for a single account), 
             # but I could not find how to restrict it even further
-            Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "/restapis/*" ] ]
+            # Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis/*" ] ]
+            Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis*" ] ]
           - Effect: Allow
             Action:
               - 's3:CreateBucket'
@@ -248,15 +250,16 @@ Resources:
               - 's3:DeleteObject'
               - 's3:PutEncryptionConfiguration'
               - 's3:GetEncryptionConfiguration'
+              - 's3:GetBucketLocation'
             # NOTE: The below is probably not true. Some permissions
             # require "conditions", and I am not sure how to define them yet.
             Resource: 
               - !GetAtt S3CodePipeline.Arn
               - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
-              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket*' ] ]
               - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
               - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
-              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket', '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket*', '/*' ] ]
           - Effect: Allow
             Action:
               - 'iam:PassRole'
@@ -267,7 +270,7 @@ Resources:
               - 'iam:DeleteRole'
             # Also not sure about this one
             Resource: 
-              # - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
+              - !Join [ '', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':role/', !Ref Service, '-', !Ref Environment, '-', !Ref 'AWS::Region', '-*' ] ]
               - !GetAtt CodeBuildRole.Arn
           - Effect: Allow
             Action:

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -205,7 +205,8 @@ Resources:
               - 'cloudformation:DescribeStackResource'
               - 'cloudformation:DescribeStackEvents'
               - 'cloudformation:UpdateStack'
-            Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
+            # Changing resource so a serverless stack can be deployed  
+            Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/*"  ] ]
           - Effect: Allow
             Action:
               - 'lambda:AddPermission'

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -223,7 +223,6 @@ Resources:
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
-              # TODO: Remove the dash before the star in the end
               - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "-*" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
@@ -237,8 +236,7 @@ Resources:
             # Note: This is still not ideal (giving access to all API
             # gateway resources in a region for a single account), 
             # but I could not find how to restrict it even further
-            # Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis/*" ] ]
-            Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', '::', "/restapis*" ] ]
+            Resource: !Join [ '', [ 'arn:aws:apigateway:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "/restapis/*" ] ]
           - Effect: Allow
             Action:
               - 's3:CreateBucket'
@@ -250,16 +248,15 @@ Resources:
               - 's3:DeleteObject'
               - 's3:PutEncryptionConfiguration'
               - 's3:GetEncryptionConfiguration'
-              - 's3:GetBucketLocation'
             # NOTE: The below is probably not true. Some permissions
             # require "conditions", and I am not sure how to define them yet.
             Resource: 
               - !GetAtt S3CodePipeline.Arn
               - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket ] ]
-              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket' ] ]
               - !Join [ '', [ !GetAtt S3CodePipeline.Arn, '/*' ] ]
               - !Join [ '', [ 'arn:aws:s3:::', !Ref HelperBucket, '/*' ] ]
-              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket*', '/*' ] ]
+              - !Join [ '', [ 'arn:aws:s3:::', !Ref Service, '-', !Ref Environment, '-', 'serverlessdeploymentbucket', '/*' ] ]
           - Effect: Allow
             Action:
               - 'iam:PassRole'
@@ -270,7 +267,7 @@ Resources:
               - 'iam:DeleteRole'
             # Also not sure about this one
             Resource: 
-              - !Join [ '', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':role/', !Ref Service, '-', !Ref Environment, '-', !Ref 'AWS::Region', '-*' ] ]
+              # - !Join [ '', [ 'arn:aws:iam:', !Ref 'AWS::AccountId', ':role/', !Ref CodeBuildRole ] ]
               - !GetAtt CodeBuildRole.Arn
           - Effect: Allow
             Action:

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -219,6 +219,8 @@ Resources:
               - 'lambda:UpdateFunctionCode'
               - 'lambda:UpdateFunctionConfiguration'
               - 'lambda:GetFunction'
+              - 'lambda:GetFunctionConfiguration'
+              - 'lambda:ListVersionsByFunction'
             Resource:
               # Giving permissions on the lambda functions created 
               # by the serverless framework, based on the assumption
@@ -312,6 +314,9 @@ Resources:
               - 'cloudformation:DescribeChangeSet'
               - 'lambda:CreateFunction'
               - 'lambda:PublishLayerVersion'
+              - 'lambda:ListTags'
+              - 'lambda:TagResource'
+              - 'lambda:UntagResource'
               - 'cloudwatch:GetMetricStatistics'
               - 'events:PutEvents'
               - 'events:PutRule'

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -222,7 +222,7 @@ Resources:
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
-              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*-" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
           - Effect: Allow
@@ -270,7 +270,7 @@ Resources:
             Action:
               - 'events:RemoveTargets'
               - 'events:DeleteRule'
-            Resource: !Join [ '', [ 'arn', !Ref 'AWS::Partition', ':events:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCodeCommitEventRule ] ]
+            Resource: !Join [ '', [ 'arn:aws:', 'events:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':rule/', !Ref CloudWatchCommitEventRule ] ]
           - Effect: Allow
             Action:
               - 'ssm:PutParameter'
@@ -286,28 +286,20 @@ Resources:
               - 'sqs:CreateQueue'
               - 'sqs:SendMessage'
               - 'sqs:GetQueueAttributes'
-              - 'sqs:ListQueues'
             Resource: !Join [ '', [ 'arn:aws:sqs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':*' ] ]
+            # Seems like there are some permissions that are 
+            # only applicable to "*" resource, maybe
           - Effect: Allow
             Action:
               - 'logs:CreateLogGroup'
               - 'logs:DeleteLogGroup'
               - 'logs:DescribeLogGroups'
               - 'logs:FilterLogEvents'
-            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
-          - Effect: Allow
-            Action:
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
               - 'logs:DescribeLogStreams'
-            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
-            # Seems like there are some permissions that are 
-            # only applicable to "*" resource, maybe
-          - Effect: Allow
-            Action:
               - 'cloudformation:ListStacks'
               - 'cloudformation:GetTemplateSummary'
-              - 'cloudformation:PreviewStackUpdate'
               - 'cloudformation:ValidateTemplate'
               - 'cloudformation:CreateUploadBucket'
               - 'cloudformation:DescribeAccountLimits'
@@ -318,6 +310,7 @@ Resources:
               - 'events:PutEvents'
               - 'events:PutRule'
               - 'events:PutTargets'
+              - 'sqs:ListQueues'
             Resource: "*"
       Roles:
         -  !Ref CodeBuildRole
@@ -346,12 +339,9 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
-          - Effect: Allow
-            Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
+            Resource: "*"
           - Effect: Allow
             Action:
               - s3:putObject
@@ -368,8 +358,7 @@ Resources:
               - codecommit:UploadArchive
               - codecommit:GetUploadArchiveStatus
               - codecommit:CancelUploadArchive
-            # Resource: !GetAtt CodeCommitRepository.Arn
-            Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+            Resource: !GetAtt CodeCommitRepository.Arn
           - Effect: Allow
             Action:
               - lambda:InvokeFunction
@@ -378,7 +367,7 @@ Resources:
               # by the serverless framework, based on the assumption
               # that serverless frameworks creates function names
               # based on service name and stage
-              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
+              - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "-*" ] ]
               # Our merger lambda function
               - !GetAtt MergeLambda.Arn
           - Effect: Allow
@@ -458,17 +447,32 @@ Resources:
               - !GetAtt CodePipelineLambdaRole.Arn
           - Effect: Allow
             Action:
-              - cloudformation:*
-            Resource: !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
+              - 'cloudformation:ListChangeSets'
+              - 'cloudformation:ListStackResources'
+              - 'cloudformation:GetStackPolicy'
+              - 'cloudformation:GetTemplate'
+              - 'cloudformation:CreateStack'
+              - 'cloudformation:DeleteStack'
+              - 'cloudformation:DescribeStacks'
+              - 'cloudformation:DescribeStackResources'
+              - 'cloudformation:DescribeStackResource'
+              - 'cloudformation:DescribeStackEvents'
+              - 'cloudformation:UpdateStack'
+              - 'cloudformation:ListStacks'
+              - 'cloudformation:GetTemplateSummary'
+              - 'cloudformation:PreviewStackUpdate'
+              - 'cloudformation:ValidateTemplate'
+              - 'cloudformation:CreateUploadBucket'
+              - 'cloudformation:DescribeAccountLimits'
+              - 'cloudformation:DescribeChangeSet'
+            Resource: 
+              - !Join [ '', [ 'arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "stack/", !Ref 'AWS::StackName' , "/*"  ] ]
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
-          - Effect: Allow
-            Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
+            Resource: "*"
       Roles:
         -  !Ref CodePipelineLambdaRole
   

--- a/templates/codepipeline-cf-template.yml
+++ b/templates/codepipeline-cf-template.yml
@@ -335,21 +335,49 @@ Resources:
           Effect: Allow
           Action:
             - logs:CreateLogGroup
+          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*' ] ]
+          Effect: Allow
+          Action:
             - logs:CreateLogStream
             - logs:PutLogEvents
+          Resource: !Join [ '', [ 'arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':log-group:/*:log-stream:*' ] ]
+          Effect: Allow
+          Action:
             - s3:putObject
             - s3:getObject
-            - codebuild:*
+          Resource:
+            # NOTE: The below is probably not true. Some permissions
+            # require "conditions", and I am not sure how to define them yet.
+            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref S3CodePipeline ] ]
+            - !Join [ '', [ 'arn:aws:s3:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref HelperBucket ] ]
+          Effect: Allow
+          Action:
             - codecommit:GetBranch
             - codecommit:GetCommit
             - codecommit:UploadArchive
             - codecommit:GetUploadArchiveStatus
             - codecommit:CancelUploadArchive
+          Resource: !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepository ] ]
+          Effect: Allow
+          Action:
             - lambda:InvokeFunction
-            - secretsmanager:GetSecretValue
-            - kms:Decrypt
           Resource:
-            - "*"
+            # Giving permissions on the lambda functions created 
+            # by the serverless framework, based on the assumption
+            # that serverless frameworks creates function names
+            # based on service name and stage
+            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref Service, "-", !Ref Environment, "*" ] ]
+            # Our merger lambda function
+            - !Join [ '', [ 'arn:aws:lambda:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "function", ':', !Ref MergeLambda ] ]
+          Effect: Allow
+          Action:
+            - secretsmanager:GetSecretValue
+          Resource: !Join [ '', [ 'arn:aws:secretsmanager:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "secret", ':', !Ref Environment, '/codepipeline/github' ] ]
+    
+          Effect: Allow
+          Action:
+            - codebuild:*
+          Resource: !Join [ '', [ 'arn:aws:codebuild:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', "project/", !Ref TestBuildDeploy ] ]
       Roles:
         -  !Ref CodePipelineRole
   


### PR DESCRIPTION
This is an experiment to tighten permissions given on AWS resources for the pipeline and the serverless stack. I have no idea if this template will deploy successfully yet, but will try.

Note, current iteration does not use resource groups, will explore that later.