### PR TITLE
[WIP] Attempt to perform schema validation

### DIFF
--- a/schemas/account.json
+++ b/schemas/account.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "The object that was changed. In this case, the `account` object.",
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string",
+          "description": "Account ID (Unique Identifier) of the Sub Account."
+        },
+        "owner_id": {
+          "type": "string",
+          "description": "User ID (Unique Identifier) of the user who owns the Sub Account."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the user who owns the Sub Account."
+        }
+      }
+}

--- a/schemas/account.json
+++ b/schemas/account.json
@@ -14,6 +14,34 @@
         "email": {
           "type": "string",
           "description": "Email address of the user who owns the Sub Account."
-        }
+        },
+        "owner_email": {
+          "type": "string",
+          "description": "Email address of the user (owner) whose Sub Account was disassociated."
+        },
+        "account_name": {
+          "type": "string",
+          "description": "Updated account name."
+        },
+        "account_alias": {
+          "type": "string",
+          "description": "Updated account alias."
+        },
+        "account_support_name": {
+          "type": "string",
+          "description": "Updated name for account support."
+        },
+        "account_support_email": {
+          "type": "string",
+          "description": "Updated email address for account support."
+        },
+        "managed_domains": {
+          "type": "array",
+          "description": "Updated managed domains.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "settings": { "$ref": "account_settings.json" }
       }
 }

--- a/schemas/account_settings.json
+++ b/schemas/account_settings.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Account/Sub Account Settings Object. Represents which settings were enabled/disabled during the update.",
+    "type": "object",
+    "properties": {
+        "schedule_meting": { "$ref": "schedule_meeting.json" },
+        "in_meeting": { "$ref": "in_meeting.json" },
+        "email_notification": { "$ref": "email_notification.json" },
+        "zoom_rooms": { "$ref": "zoom_rooms.json" },
+        "security": { "$ref": "security_settings.json" },
+        "recording": { "$ref": "recording_settings.json" },
+        "telephony": { "$ref": "telephony_settings.json" },
+        "integration": { "$ref": "integration_settings.json" },
+        "feature": { "$ref": "feature.json" }
+      }
+}

--- a/schemas/base.json
+++ b/schemas/base.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ZoomEventInputModel",
+    "description": "Base schema containing all types of Zoom events.",
+    "type": "object",
+    "properties": {
+        "event": {
+            "type": "string",
+            "description": "Name of the event. "
+          },
+        "payload": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                  "type": "string",
+                  "description": "The account ID of the meeting host (user who created the meeting). "
+                },
+                "operator": {
+                  "type": "string",
+                  "description": "The email address of the user who created the meeting.",
+                  "format": "email"
+                },
+                "operator_id": {
+                  "type": "string",
+                  "description": "The user ID of the operator who created the meeting."
+                },
+                "operation": {
+                  "type": "string",
+                  "enum": [
+                    "all",
+                    "single"
+                  ],
+                  "description": "`all"
+                },
+                "creation_type": {
+                  "type": "string",
+                  "description": "The method used to create the user. ",
+                  "enum": [
+                    "create",
+                    "ssoCreate",
+                    "autoCreate",
+                    "autoCreate2",
+                    "custCreate"
+                  ]
+                },
+                "time_stamp": {
+                  "type": "integer",
+                  "description": "Timestamp of the update in milliseconds."
+                },
+                "old_object": { "$ref": "old_object.json" },
+                "object": { "$ref": "meeting.json" },
+                "object": { "$ref": "recording.json" },
+                "object": { "$ref": "user.json" }
+              }
+
+        },
+        "operator_id": {
+          "type": "string",
+          "description": "The User ID of the operator who deactivated the user."
+        },
+        "operation": {
+          "type": "string",
+          "description": "This field will be returned only if an operation is performed such as when a user applies for a Vanity URL. "
+        }
+    },
+    "required": ["event", "payload"]
+}

--- a/schemas/email_notification.json
+++ b/schemas/email_notification.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Email Notification settings object.",
+    "type": "object",
+    "properties": {
+        "cloud_recording_avaliable_reminder": {
+          "type": "boolean",
+          "description": "Notify host when cloud recording is available."
+        },
+        "jbh_reminder": {
+          "type": "boolean",
+          "description": "Notify the host when participants join the meeting before them."
+        },
+        "cancel_meeting_reminder": {
+          "type": "boolean",
+          "description": "Notify the host and participants when a meeting is cancelled."
+        },
+        "low_host_count_reminder": {
+          "type": "boolean",
+          "description": "Notify user when host licenses are running low."
+        },
+        "alternative_host_reminder": {
+          "type": "boolean",
+          "description": "Notify when an alternative host is set or removed from a meeting."
+        }
+      }
+}

--- a/schemas/feature.json
+++ b/schemas/feature.json
@@ -6,6 +6,22 @@
         "meeting_capacity": {
           "type": "integer",
           "description": "Set the maximum number of participants a host can have in a single meeting."
+        },
+        "large_meeting": {
+          "description": "Shows if large meeting feature is enabled for user or not.",
+          "type": "boolean"
+        },
+        "large_meeting_capacity": {
+          "type": "integer",
+          "description": "The number of meeting participants that are allowed on a per month or yearly basis depending on the [large meeting plan](https://marketplace.zoom.us/docs/api-reference/other-references/plans#largemeetingplans) that is enabled for the user of the account."
+        },
+        "webinar": {
+          "type": "boolean",
+          "description": "Indicates whether or not a webinar plan is enabled for the user."
+        },
+        "webinar_capacity": {
+          "type": "integer",
+          "description": "The number of meeting participants that are allowed on a per month or yearly basis depending on the [webinar plan](https://marketplace.zoom.us/docs/api-reference/other-references/plans#webinar-plans) that is enabled for the user of the account."
         }
       }
 }

--- a/schemas/feature.json
+++ b/schemas/feature.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Feature",
+    "type": "object",
+    "properties": {
+        "meeting_capacity": {
+          "type": "integer",
+          "description": "Set the maximum number of participants a host can have in a single meeting."
+        }
+      }
+}

--- a/schemas/in_meeting.json
+++ b/schemas/in_meeting.json
@@ -1,0 +1,155 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "In Meeting object.",
+    "type": "object",
+    "properties": {
+        "e2e_encryption": {
+          "type": "boolean",
+          "description": "Requirement for meetings to be encrypted using AES."
+        },
+        "chat": {
+          "type": "boolean",
+          "description": "Enable chat between meeting participants."
+        },
+        "private_chat": {
+          "type": "boolean",
+          "description": "Enable private chat message between meeting participants."
+        },
+        "auto_saving_chat": {
+          "type": "boolean",
+          "description": "Save all in-meeting chats automatically."
+        },
+        "file_transfer": {
+          "type": "boolean",
+          "description": "Enable file sharing via in-meeting chat."
+        },
+        "feedback": {
+          "type": "boolean",
+          "description": "Feedback enabled for users to provide meeting feedback."
+        },
+        "post_meeting_feedback": {
+          "type": "boolean",
+          "description": "A thumbs up or down survey enabled at the end of a meeting."
+        },
+        "co_host": {
+          "type": "boolean",
+          "description": "Setting for host to add co-hosts."
+        },
+        "polling": {
+          "type": "boolean",
+          "description": "Polls added to the meeting controls."
+        },
+        "attendee_on_hold": {
+          "type": "boolean",
+          "description": "Allow hosts to temporarily remove an attendee from a meeting."
+        },
+        "show_meeting_control_toolbar": {
+          "type": "boolean",
+          "description": "Always show the meeting control bar."
+        },
+        "allow_show_zoom_windows": {
+          "type": "boolean",
+          "description": "Show the Zoom desktop application when sharing access."
+        },
+        "annotation": {
+          "type": "boolean",
+          "description": "Allow participants to use annotation tools to add information to shared screens."
+        },
+        "whiteboard": {
+          "type": "boolean",
+          "description": "Allow participants to share a whiteboard that includes annotation tools."
+        },
+        "webinar_question_answer": {
+          "type": "boolean",
+          "description": "Allow Q&A in a webinar."
+        },
+        "anonymous_question_answer": {
+          "type": "boolean",
+          "description": "Allow an anonymous Q&A during a webinar."
+        },
+        "breakout_room": {
+          "type": "boolean",
+          "description": "Allow host to split meeting participants into separate, smaller rooms."
+        },
+        "closed_caption": {
+          "type": "boolean",
+          "description": "Enable a host to add closed captions."
+        },
+        "far_end_camera_control": {
+          "type": "boolean",
+          "description": "Another user enabled to take control of camera during a meeting."
+        },
+        "group_hd": {
+          "type": "boolean",
+          "description": "Enable higher quality video for host and participants."
+        },
+        "virtual_background": {
+          "type": "boolean",
+          "description": "Enable users to change their background."
+        },
+        "watermark": {
+          "type": "boolean",
+          "description": "Add watermark when viewing a shared screen."
+        },
+        "alert_guest_join": {
+          "type": "boolean",
+          "description": "Alert when a guest joins a meeting."
+        },
+        "auto_answer": {
+          "type": "boolean",
+          "description": "Enable users to see and add contacts to the \\\"auto-answer group\\\" in the chat contact list. Any call from members of this group will automatically be answered."
+        },
+        "p2p_connetion": {
+          "type": "boolean",
+          "description": "Peer to peer connection while only two people are in a meeting."
+        },
+        "p2p_ports": {
+          "type": "boolean",
+          "description": "Peer to peer listening ports range."
+        },
+        "ports_range": {
+          "type": "string",
+          "description": "The listening ports range, separated by a comma (ex 55,56). The ports range must be between 1 to 65535."
+        },
+        "sending_default_email_invites": {
+          "type": "boolean",
+          "description": "Only show the default email when sending email invites."
+        },
+        "use_html_format_email": {
+          "type": "boolean",
+          "description": "Use HTML formatted email for the Outlook plugin."
+        },
+        "dscp_marking": {
+          "type": "boolean",
+          "description": "DSCP marking."
+        },
+        "dscp_audio": {
+          "type": "integer",
+          "description": "DSCP audio"
+        },
+        "dscp_video": {
+          "type": "integer",
+          "description": "DSCP video"
+        },
+        "stereo_audio": {
+          "type": "boolean",
+          "description": "Allow users to select stereo audio in their client settings."
+        },
+        "original_audio": {
+          "type": "boolean",
+          "description": "Allow users to select original sound in their client settings."
+        },
+        "screen_sharing": {
+          "type": "boolean",
+          "description": "Allow screen sharing."
+        },
+        "remote_control": {
+          "type": "boolean",
+          "description": "Allow users to request remote control."
+        },
+        "attention_tracking": {
+          "type": "boolean",
+          "description": "Allows the host to see an indicator in the participant panel if a meeting or webinar attendee does not have Zoom in focus while screen sharing."
+        }
+      }
+}

--- a/schemas/in_meeting.json
+++ b/schemas/in_meeting.json
@@ -19,29 +19,9 @@
           "type": "boolean",
           "description": "Save all in-meeting chats automatically."
         },
-        "file_transfer": {
-          "type": "boolean",
-          "description": "Enable file sharing via in-meeting chat."
-        },
-        "feedback": {
-          "type": "boolean",
-          "description": "Feedback enabled for users to provide meeting feedback."
-        },
         "post_meeting_feedback": {
           "type": "boolean",
           "description": "A thumbs up or down survey enabled at the end of a meeting."
-        },
-        "co_host": {
-          "type": "boolean",
-          "description": "Setting for host to add co-hosts."
-        },
-        "polling": {
-          "type": "boolean",
-          "description": "Polls added to the meeting controls."
-        },
-        "attendee_on_hold": {
-          "type": "boolean",
-          "description": "Allow hosts to temporarily remove an attendee from a meeting."
         },
         "show_meeting_control_toolbar": {
           "type": "boolean",
@@ -50,10 +30,6 @@
         "allow_show_zoom_windows": {
           "type": "boolean",
           "description": "Show the Zoom desktop application when sharing access."
-        },
-        "annotation": {
-          "type": "boolean",
-          "description": "Allow participants to use annotation tools to add information to shared screens."
         },
         "whiteboard": {
           "type": "boolean",
@@ -66,26 +42,6 @@
         "anonymous_question_answer": {
           "type": "boolean",
           "description": "Allow an anonymous Q&A during a webinar."
-        },
-        "breakout_room": {
-          "type": "boolean",
-          "description": "Allow host to split meeting participants into separate, smaller rooms."
-        },
-        "closed_caption": {
-          "type": "boolean",
-          "description": "Enable a host to add closed captions."
-        },
-        "far_end_camera_control": {
-          "type": "boolean",
-          "description": "Another user enabled to take control of camera during a meeting."
-        },
-        "group_hd": {
-          "type": "boolean",
-          "description": "Enable higher quality video for host and participants."
-        },
-        "virtual_background": {
-          "type": "boolean",
-          "description": "Enable users to change their background."
         },
         "watermark": {
           "type": "boolean",
@@ -143,13 +99,81 @@
           "type": "boolean",
           "description": "Allow screen sharing."
         },
+        "entry_exit_chime": {
+          "type": "string",
+          "description": "The sound that plays when participants join or leave the meeting:<br>\n`host`: When host joins or leaves a meeting.<br>`all`: When any participant joins or leaves a meeting.<br> `none`: Disable this setting to not play any sound."
+        },
+        "record_play_voice": {
+          "type": "boolean",
+          "description": "When a participant joins by telephone, record and play the participant's own voice."
+        },
+        "file_transfer": {
+          "description": "Setting to enable hosts and participants to send files through the in-meeting chat.",
+          "type": "boolean"
+        },
+        "feedback": {
+          "type": "boolean",
+          "description": "Enable option to send feedback to Zoom at the end of the meeting."
+        },
+        "co_host": {
+          "description": "Allow the host to add co-hosts.",
+          "type": "boolean"
+        },
+        "polling": {
+          "description": "Add polls to the meeting controls.",
+          "type": "boolean"
+        },
+        "attendee_on_hold": {
+          "description": "Allow host to put attendee on hold.",
+          "type": "boolean"
+        },
+        "annotation": {
+          "description": "Allow participants to use annotation tools.",
+          "type": "boolean"
+        },
         "remote_control": {
           "type": "boolean",
-          "description": "Allow users to request remote control."
+          "description": "Enable remote control during screensharing."
+        },
+        "non_verbal_feedback": {
+          "description": "Enable non-verbal feedback through screens.",
+          "type": "boolean"
+        },
+        "breakout_room": {
+          "type": "boolean",
+          "description": "Allow host to split meeting participants into separate breakout rooms."
+        },
+        "remote_support": {
+          "type": "boolean",
+          "description": "Allow host to provide 1:1 remote support to a participant."
+        },
+        "closed_caption": {
+          "type": "boolean",
+          "description": "Enable closed captions."
+        },
+        "group_hd": {
+          "type": "boolean",
+          "description": "Enable group HD video."
+        },
+        "virtual_background": {
+          "type": "boolean",
+          "description": "Enable virtual background."
+        },
+        "far_end_camera_control": {
+          "type": "boolean",
+          "description": "Allow another user to take control of the camera."
+        },
+        "share_dual_camera": {
+          "type": "boolean",
+          "description": "Share dual camera (deprecated)."
         },
         "attention_tracking": {
           "type": "boolean",
-          "description": "Allows the host to see an indicator in the participant panel if a meeting or webinar attendee does not have Zoom in focus while screen sharing."
+          "description": "Allow host to see if a participant does not have Zoom in focus during screen sharing."
+        },
+        "waiting_room": {
+          "type": "boolean",
+          "description": "Enable Waiting room - if enabled, attendees can only join after host approves."
         }
       }
 }

--- a/schemas/integration_settings.json
+++ b/schemas/integration_settings.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Integration settings",
+    "type": "object",
+    "properties": {
+        "google_calendar": {
+          "type": "boolean",
+          "description": "Enable meetings to be scheduled using Google Calendar.\""
+        },
+        "google_drive": {
+          "type": "boolean",
+          "description": "Enable users who join a meeting from their mobile device to share content from their Google Drive."
+        },
+        "dropbox": {
+          "type": "boolean",
+          "description": "Enable users who join a meeting from their mobile device to share content from their Dropbox account."
+        },
+        "box": {
+          "type": "boolean",
+          "description": "Enable users who join a meeting from their mobile device to share content from their Box account."
+        },
+        "microsoft_one_drive": {
+          "type": "boolean",
+          "description": "Enable users who join a meeting from their mobile device to share content from their Microsoft OneDrive account."
+        },
+        "kubi": {
+          "type": "boolean",
+          "description": "Enable users to control a connected Kubi device from within a Zoom meeting."
+        }
+      }
+}

--- a/schemas/meeting.json
+++ b/schemas/meeting.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Zoom Meeting object",
+    "description": "Meeting object",
     "type": "object",
     "properties": {
         "id": {

--- a/schemas/meeting.json
+++ b/schemas/meeting.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Zoom Meeting object",
+    "type": "object",
+    "properties": {
+        "id": {
+          "description": "Meeting ID - also known as the meeting number.",
+          "type": "integer"
+        },
+        "uuid": {
+          "type": "string",
+          "description": "Unique Meeting ID. Each meeting instance will generate its own meeting UUID."
+        },
+        "host_id": {
+          "type": "string",
+          "description": "ID of the user who is set as the host of the meeting."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Meeting Topic"
+        },
+        "type": {
+          "description": "Meeting Types:<br> `1` - Instant Meeting<br> `2` - Scheduled Meeting<br> `3` - Recurring Meeting with no fixed time.<br> `8` - Recurring Meeting with a fixed time. ",
+          "type": "integer"
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Meeting start time.",
+          "format": "date-time"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone to format the meeting start time."
+        },
+        "duration": {
+          "description": "Meeting duration.",
+          "type": "integer"
+        },
+        "occurrences": { "$ref": "occurences.json" },
+        "participant": { "$ref": "participant.json" }
+      }
+}

--- a/schemas/meeting.json
+++ b/schemas/meeting.json
@@ -36,7 +36,83 @@
           "description": "Meeting duration.",
           "type": "integer"
         },
+        "password": {
+          "type": "string",
+          "description": "Password used to join the meeting. "
+        },
+        "h323_password": {
+          "type": "string",
+          "description": "Password to join the meeting from H323 device. "
+        },
+        "pstn_password": {
+          "type": "string",
+          "description": "PSTN password to join the meeting."
+        },
+        "encrypted_password": {
+          "type": "string",
+          "description": "Encrypted password of the meeting."
+        },
+        "agenda": {
+          "type": "string",
+          "description": "Meeting Agenda."
+        },
+        "registration_url": {
+          "type": "string",
+          "description": "Registration URL for the meeting."
+        },
+        "issues": {
+          "type": "string",
+          "enum": [
+            "Unstable audio quality",
+            "Unstable video quality",
+            "Unstable screen share quality",
+            "High CPU occupation",
+            "Call Reconnection"
+          ],
+          "description": "Issues that occurred during the meeting."
+        },
+        "room_name": {
+          "type": "string",
+          "description": "Name of the Zoom Room."
+        },
+        "calendar_name": {
+          "type": "string",
+          "description": "Name of the Calendar."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address associated with the Zoom Room.",
+          "format": "email"
+        },
+        "issue": {
+          "type": "string",
+          "description": "Issues that occurred during the meeting. The value of the `issue` field could be one of the following:<br>\n* `Room Controller disconnected`<br>\n* `Room Controller connected`\n* `Selected camera has disconnected`\n* `Selected camera is reconnected`\n* `Selected microphone has disconnected`\n* `Selected microphone is reconnected`\n* `Selected speaker has disconnected`\n* `Selected speaker is reconnected`\n* `Zoom room is offline`\n* `Zoom room is online`\n* `No camera`\n* `No microphone`\n* `High CPU usage is detected`\n* `Low bandwidth network is detected`\n* `{name} battery is low`\n* `{name} battery is normal`\n* `{name} disconnected`\n* `{name} connected`\n* `{name} is not charging`\n\nPossible values for {name}: <br>\n* Zoom Rooms Computer \n* Controller\n* Scheduling Display"
+        },
         "occurrences": { "$ref": "occurences.json" },
-        "participant": { "$ref": "participant.json" }
+        "registrant": { "$ref": "registrant.json" },
+        "recurrence": { "$ref": "recurrence.json" },
+        "participant": { "$ref": "participant.json" },
+        "tracking_fields": {
+          "type": "array",
+          "description": "[Tracking fields.](https://support.zoom.us/hc/en-us/articles/115000293426-Scheduling-Tracking-Fields)",
+          "items": {
+            "type": "object",
+            "properties": {
+              "field": {
+                "type": "string",
+                "description": "Label for the tracking field."
+              },
+              "value": {
+                "type": "string",
+                "description": "Value for the field."
+              }
+            }
+          }
+        },
+        "settings": { "$ref": "meeting_settings.json" },
+        "join_url": {
+          "type": "string",
+          "description": "The url to join the meeting."
+        }
       }
 }

--- a/schemas/meeting_settings.json
+++ b/schemas/meeting_settings.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Settings object. It represents which options were enabled or disabled during the meeting update.",
+    "type": "object",
+    "properties": {
+        "host_video": {
+          "type": "boolean",
+          "description": "Start the video with host video on.\n"
+        },
+        "participant_video": {
+          "type": "boolean",
+          "description": "Turn participant's video on when they join the meeting. Participants can change this during the meeting."
+        },
+        "join_before_host": {
+          "type": "boolean",
+          "description": "Allow participants to join the meeting before host arrives."
+        },
+        "mute_upon_entry": {
+          "type": "boolean",
+          "description": "Mute participants upon entry."
+        },
+        "audio": {
+          "type": "string",
+          "description": "The audio options for participants joining the meeting. <br>\n`telephony` - Telephony only.\n`voip` - VoIP only.<br>\n`both` - Both Telephony and VoIP."
+        },
+        "auto_recording": {
+          "type": "string",
+          "description": "Automatically record the meeting with either of the following options:<br>\n`local`: Record and save to the local device.<br> `cloud`: Record to the cloud.<br>\n`none`: Autorecording disabled.\n\n"
+        },
+        "use_pmi": {
+          "type": "boolean",
+          "description": "Use personal meeting ID."
+        },
+        "waiting_room": {
+          "type": "boolean",
+          "description": "Enable [waiting room](https://support.zoom.us/hc/en-us/articles/115000332726-Waiting-Room)."
+        },
+        "watermark": {
+          "type": "boolean",
+          "description": "Enable [watermark](https://support.zoom.us/hc/en-us/articles/209605273-Adding-a-Watermark)."
+        },
+        "enforce_login": {
+          "type": "boolean",
+          "description": "Only signed in users can join this meeting."
+        },
+        "enforce_login_domains": {
+          "type": "string",
+          "description": "Only signed in users with specified domain can join this meeting."
+        },
+        "approval_type": {
+          "type": "integer",
+          "description": "Approval type for meeting registrants.<br>`0`: Automatically approve.<br>`1`: Manually approve.<br>`2`: Registration not required."
+        },
+        "alternative_hosts": {
+          "type": "string",
+          "description": "Alternative hosts' emails or IDs: multiple values are separated by comma."
+        }
+      }
+}

--- a/schemas/occurences.json
+++ b/schemas/occurences.json
@@ -1,20 +1,19 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Zoom Occurences object",
     "type": "array",
-          "description": "Array of occurence objects. Only returned for meeting `type` with a value of 8, i.e. if the meeting is a recurrence meeting with fixed time.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "occurrence_id": {
-                "description": "Occurrence ID",
-                "type": "string"
-              },
-              "start_time": {
-                "type": "string",
-                "description": "Start time",
-                "format": "date-time"
-              }
-            }
-          }
+    "description": "Array of occurence objects. Only returned for meeting `type` with a value of 8, i.e. if the meeting is a recurrence meeting with fixed time.",
+    "items": {
+      "type": "object",
+      "properties": {
+        "occurrence_id": {
+        "description": "Occurrence ID",
+        "type": "string"
+        },
+      "start_time": {
+        "type": "string",
+        "description": "Start time",
+        "format": "date-time"
+        }
+      }
+    }
 }

--- a/schemas/occurences.json
+++ b/schemas/occurences.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Zoom Occurences object",
+    "type": "array",
+          "description": "Array of occurence objects. Only returned for meeting `type` with a value of 8, i.e. if the meeting is a recurrence meeting with fixed time.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "occurrence_id": {
+                "description": "Occurrence ID",
+                "type": "string"
+              },
+              "start_time": {
+                "type": "string",
+                "description": "Start time",
+                "format": "date-time"
+              }
+            }
+          }
+}

--- a/schemas/old_object.json
+++ b/schemas/old_object.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Represents the object before it was updated.",
+    "type": "object",
+    "properties": {
+        "$changed_category": {
+          "type": "object",
+          "description": "The category that was changed",
+          "properties": {
+            "$changed_field_name": {
+              "type": [
+                "string",
+                "object",
+                "number",
+                "boolean",
+                "integer",
+                "array"
+              ],
+              "description": "The name of the field that was changed and its corresponding value."
+            }
+          }
+        }
+      }
+}

--- a/schemas/participant.json
+++ b/schemas/participant.json
@@ -15,37 +15,15 @@
           "type": "string",
           "description": "User Id of the participant. Same as the User Id used in the [Users API](https://marketplace.zoom.us/docs/api-reference/zoom-api/users/usercreate) if participant joined the meeting by logging in. "
         },
-        "sharing_details": {
-          "type": "object",
-          "description": "Sharing details object contains information about the screenshare. ",
-          "properties": {
-            "content": {
-              "type": "string",
-              "description": "The type of content that was shared.",
-              "enum": [
-                "application",
-                "whiteboard",
-                "desktop"
-              ]
-            },
-            "link_source": {
-              "type": "string",
-              "description": "Represents the method of sharing for dropbox integration.",
-              "enum": [
-                "deep_link",
-                "in_meeting"
-              ]
-            },
-            "file_link": {
-              "type": "string",
-              "description": "The link using which the file was shared via dropbox integration."
-            },
-            "date_time": {
-              "type": "string",
-              "format": "date-time",
-              "description": "The date and time during which the screenshare happened."
-            }
-          }
-        }
+        "join_time": {
+          "type": "string",
+          "description": "The time at which the participant joined the meeting."
+        },
+        "leave_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the participant left the meeting."
+        },
+        "sharing_details": { "$ref": "sharing_details.json" }
       }
 }

--- a/schemas/participant.json
+++ b/schemas/participant.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Zoom Participant object",
     "description": "Participant object that contains information about the participant.",
     "type": "object",
     "properties": {

--- a/schemas/participant.json
+++ b/schemas/participant.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Zoom Participant object",
+    "description": "Participant object that contains information about the participant.",
+    "type": "object",
+    "properties": {
+        "user_id": {
+          "type": "string",
+          "description": "Unique Participant Identifier. This is unique for each meeting participant and is valid only for that meeting."
+        },
+        "user_name": {
+          "type": "string",
+          "description": "Participant's name."
+        },
+        "id": {
+          "type": "string",
+          "description": "User Id of the participant. Same as the User Id used in the [Users API](https://marketplace.zoom.us/docs/api-reference/zoom-api/users/usercreate) if participant joined the meeting by logging in. "
+        },
+        "sharing_details": {
+          "type": "object",
+          "description": "Sharing details object contains information about the screenshare. ",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The type of content that was shared.",
+              "enum": [
+                "application",
+                "whiteboard",
+                "desktop"
+              ]
+            },
+            "link_source": {
+              "type": "string",
+              "description": "Represents the method of sharing for dropbox integration.",
+              "enum": [
+                "deep_link",
+                "in_meeting"
+              ]
+            },
+            "file_link": {
+              "type": "string",
+              "description": "The link using which the file was shared via dropbox integration."
+            },
+            "date_time": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The date and time during which the screenshare happened."
+            }
+          }
+        }
+      }
+}

--- a/schemas/recording.json
+++ b/schemas/recording.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Recording object",
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string",
+          "description": "Cloud Recording ID"
+        },
+        "uuid": {
+          "type": "string",
+          "description": "Universally Unique identifier for the recording instance."
+        },
+        "host_id": {
+          "type": "string",
+          "description": "ID of the user who is set as the host of the meeting/webinar."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Meeting/Webinar topic."
+        },
+        "type": {
+          "type": "integer",
+          "description": "Meeting Types:<br>`1` - Instant meeting.<br>`2` - Scheduled meeting.<br>`3` - Recurring meeting with no fixed time.<br>`8` - Recurring meeting with fixed time.\"",
+          "enum": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Meeting/Webinar start time.",
+          "format": "date-time"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone of the Meeting/Webinar."
+        },
+        "duration": {
+          "type": "integer",
+          "description": "Scheduled duration of the meeting/webinar."
+        },
+        "recording_file": { "$ref": "recoding_file.json" }
+      }
+
+}

--- a/schemas/recording.json
+++ b/schemas/recording.json
@@ -26,7 +26,10 @@
             1,
             2,
             3,
-            8
+            5,
+            6,
+            8,
+            9
           ]
         },
         "start_time": {
@@ -42,7 +45,26 @@
           "type": "integer",
           "description": "Scheduled duration of the meeting/webinar."
         },
-        "recording_file": { "$ref": "recoding_file.json" }
+        "share_url": {
+          "type": "string",
+          "description": "The URL of the recording using which approved users can view the recording."
+        },
+        "total_size": {
+          "description": "The total size of the recording in bytes.",
+          "type": "integer"
+        },
+        "recording_count": {
+          "description": "The number of recording files recovered.",
+          "type": "integer"
+        },
+        "recording_file": { "$ref": "recoding_file.json" },
+        "recording_files": { "$ref": "recoding_files.json" },
+        "host_email": {
+          "type": "string",
+          "description": "Email address of the host.",
+          "format": "email"
+        },
+        "occurrences": { "$ref": "occurrences.json" },
+        "registrant": { "$ref": "registrant.json" }
       }
-
 }

--- a/schemas/recording_file.json
+++ b/schemas/recording_file.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Array of recording file objects recovered.",
+    "type": "object",
+    "properties": {
+        "recording_start": {
+          "type": "string",
+          "description": "The date and time at which the recording started.",
+          "format": "date-time"
+        },
+        "recording_end": {
+          "type": "string",
+          "description": "The date and time at which the recording ended.",
+          "format": "date-time"
+        }
+      }
+}

--- a/schemas/recording_files.json
+++ b/schemas/recording_files.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "description": "Array of recording file objects recovered.",
+    "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique Identifier for Recording File. Recording File ID."
+          },
+          "meeting_id": {
+            "type": "string",
+            "description": "Unique Identifier of the meeting."
+          },
+          "recording_start": {
+            "type": "string",
+            "description": "The date and time at which recording started.",
+            "format": "date-time"
+          },
+          "recording_end": {
+            "type": "string",
+            "description": "The date and time at which recording ended."
+          },
+          "file_type": {
+            "type": "string",
+            "description": "The type of file."
+          },
+          "file_size": {
+            "type": "integer",
+            "description": "The size of the recording file in bytes."
+          },
+          "play_url": {
+            "type": "string",
+            "description": "The URL of the file using which it can be opened and played."
+          },
+          "download_url": {
+            "type": "string",
+            "description": "The URL using which the file can be downloaded."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the recording. <br>`completed`: Recording has been completed."
+          },
+          "recording_type": {
+            "type": "string",
+            "description": "The type of the recording."
+          }
+        }
+      }
+}

--- a/schemas/recording_settings.json
+++ b/schemas/recording_settings.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Recording Settings Object",
+    "type": "object",
+    "properties": {
+        "local_recording": {
+          "type": "boolean",
+          "description": "Allow hosts and participants to record the meeting using a local file."
+        },
+        "cloud_recording": {
+          "type": "boolean",
+          "description": "Allow hosts to record and save the meeting in the cloud."
+        },
+        "record_speaker_view": {
+          "type": "boolean",
+          "description": "Record the active speaker with a shared screen."
+        },
+        "record_gallery_view": {
+          "type": "boolean",
+          "description": "Record the gallery view with a shared screen."
+        },
+        "record_audio_file": {
+          "type": "boolean",
+          "description": "Record an audio only file."
+        },
+        "save_chat_text": {
+          "type": "boolean",
+          "description": "Save the chat text from the meeting."
+        },
+        "show_timestamp": {
+          "type": "boolean",
+          "description": "Add a timestamp to the recording."
+        },
+        "recording_audio_transcript": {
+          "type": "boolean",
+          "description": "Automatically transcribe the audio of the meeting or webinar to the cloud."
+        },
+        "auto_recording": {
+          "type": "string",
+          "description": "Automatic recording:<br>`local` - Record on local.<br>`cloud` -  Record on cloud.<br>`none` - Disabled."
+        },
+        "cloud_recording_download": {
+          "type": "boolean",
+          "description": "Enable cloud recording downloads"
+        },
+        "cloud_recording_download_host": {
+          "type": "boolean",
+          "description": "Only the host can download cloud recordings."
+        },
+        "account_user_access_recording": {
+          "type": "boolean",
+          "description": "Cloud recordings are only accessible to account members. People outside of your organization cannot open links that provide access to cloud recordings."
+        },
+        "auto_delete_cmr": {
+          "type": "boolean",
+          "description": "Allow Zoom to permanantly delete recordings automatically after a specified number of days."
+        },
+        "auto_delete_cmr_days": {
+          "type": "integer",
+          "description": "When `auto_delete_cmr` function is 'true' this value will set the number of days before the auto deletion of cloud recordings."
+        }
+      }
+}

--- a/schemas/recurrence.json
+++ b/schemas/recurrence.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Recurrence object.",
+    "type": "object",
+    "properties": {
+        "type": {
+          "type": "integer",
+          "description": "Recurrence meeting types:<br>\n`1` - Daily <br>\n`2` - Weekly <br>\n`3` - Monthly",
+          "enum": [
+            1,
+            2,
+            3
+          ]
+        },
+        "repeat_interval": {
+          "type": "integer",
+          "description": "The interval at which the meeting should repeat. For a daily meeting, the maximum interval can be 90 days. For a weekly meeting, the maximum interval period is 12 weeks. For a monthly meeting, the maximum interval is 3 months."
+        },
+        "weekly_days": {
+          "type": "integer",
+          "description": "Days on which the meeting repeats. <br>\n`1` - Sunday<br>\n`2` - Monday<br>\n`3` - Tuesday<br>\n`4` - Wednesday<br>\n`5` - Thursday<br>\n`6` - Friday<br>\n`7` - Saturday"
+        },
+        "monthly_day": {
+          "type": "integer",
+          "description": "Day in the month the meeting is to be scheduled. The value ranges from 1 to 31."
+        },
+        "monthly_week_day": {
+          "description": "The day of the week on which a meeting recurs each month.<br>\n`1` - Sunday<br>\n`2` - Monday<br>\n`3` - Tuesday<br>\n`4` - Wednesday<br>\n`5` - Thursday<br>\n`6` - Friday<br>\n`7` - Saturday",
+          "type": "integer"
+        },
+        "end_times": {
+          "description": "Shows how many times a meeting has been scheduled to recur. The maximum number of times that a meeting can recur is 50.",
+          "default": 1,
+          "type": "integer"
+        },
+        "end_date_time": {
+          "type": "string",
+          "description": "The date and time until which the meeting recurs.",
+          "format": "date-time"
+        },
+        "monthly_week": {
+          "type": "integer",
+          "description": "The week on which a meeting recurs each month."
+        }
+      }
+}

--- a/schemas/registrant.json
+++ b/schemas/registrant.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Registrant object",
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string",
+          "description": "Registrant ID"
+        },
+        "email": {
+          "type": "string",
+          "description": "Registrant Email",
+          "format": "email"
+        },
+        "first_name": {
+          "type": "string",
+          "description": "Registrant's first name"
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Registrant's last name"
+        },
+        "address": {
+          "type": "string",
+          "description": "Registrant's address"
+        },
+        "city": {
+          "type": "string",
+          "description": "Registrant's city"
+        },
+        "country": {
+          "type": "string",
+          "description": "Registrant's country"
+        },
+        "zip": {
+          "type": "string",
+          "description": "Registrant's zip"
+        },
+        "state": {
+          "type": "string",
+          "description": "Registrant's state"
+        },
+        "phone": {
+          "type": "string",
+          "description": "Registrant's phone"
+        },
+        "industry": {
+          "type": "string",
+          "description": "Registrant's industry"
+        },
+        "org": {
+          "type": "string",
+          "description": "Registrant's organization"
+        },
+        "job_title": {
+          "type": "string",
+          "description": "Registrant's job title"
+        },
+        "purchasing_time_frame": {
+          "type": "string",
+          "description": "Purchasing Time Frame:<br>`Within a month`<br>`1-3 months`<br>`4-6 months`<br>`More than 6 months`<br>`No timeframe`"
+        },
+        "role_in_purchase_process": {
+          "type": "string",
+          "description": "\"Role in Purchase Process:<br>`Decision Maker`<br>`Evaluator/Recommender`<br>`Influencer`<br>`Not involved`"
+        },
+        "no_of_employees": {
+          "type": "string",
+          "description": "Number of Employees:<br>`1-20`<br>`21-50`<br>`51-100`<br>`101-500`<br>`500-1,000`<br>`1,001-5,000`<br>`5,001-10,000`<br>`More than 10,000`"
+        },
+        "comments": {
+          "type": "string",
+          "description": "Questions and comments."
+        },
+        "custom_questions": {
+          "type": "array",
+          "description": "Custom questions.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "join_url": {
+          "type": "string",
+          "description": "Join URL for the meeting."
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the registration: <br> `approve`: Approved registrant.<br> `pending`: Registration approval pending."
+        }
+      }
+}

--- a/schemas/schedule_meeting.json
+++ b/schemas/schedule_meeting.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schedule Meeting object.",
+    "type": "object",
+    "properties": {
+        "host_video": {
+          "type": "boolean",
+          "description": "Start meetings with the host video on. "
+        },
+        "participant_video": {
+          "type": "boolean",
+          "description": "Start meetings with the participant video on. "
+        },
+        "audio_type": {
+          "type": "string",
+          "description": "The audio type used to join the meeting."
+        },
+        "join_before_host": {
+          "type": "boolean",
+          "description": "Enable participants to join before host."
+        },
+        "enforce_login": {
+          "type": "boolean",
+          "description": "Enable only those users who are signed in to Zoom to join the meeting."
+        },
+        "enforce_login_with_domains": {
+          "type": "boolean",
+          "description": "Only users with a specific domain can join the meetings."
+        },
+        "enforce_login_domains": {
+          "type": "string",
+          "description": "Specify domains for users to sign in to and join the meeting."
+        },
+        "not_store_meeting_topic": {
+          "type": "boolean",
+          "description": "Display \"Zoom Meeting\" as the meeting topic."
+        },
+        "force_pmi_jbh_password": {
+          "type": "boolean",
+          "description": "Require password for Personal Meetings if attendees can join before host."
+        }
+      }
+}

--- a/schemas/schedule_meeting.json
+++ b/schemas/schedule_meeting.json
@@ -11,6 +11,10 @@
           "type": "boolean",
           "description": "Start meetings with the participant video on. "
         },
+        "participants_video": {
+          "description": "Start meetings with participant video on.",
+          "type": "boolean"
+        },
         "audio_type": {
           "type": "string",
           "description": "The audio type used to join the meeting."
@@ -38,6 +42,10 @@
         "force_pmi_jbh_password": {
           "type": "boolean",
           "description": "Require password for Personal Meetings if attendees can join before host."
+        },
+        "pstn_password_protected": {
+          "type": "string",
+          "description": "Require password from participants before joining a meeting via [PSTN](https://support.zoom.us/hc/en-us/articles/204517069-Getting-Started-with-Personal-Audio-Conference)."
         }
       }
 }

--- a/schemas/security_settings.json
+++ b/schemas/security_settings.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Security Settings Object",
+    "type": "object",
+    "properties": {
+        "admin_change_name_pic": {
+          "type": "boolean",
+          "description": "Provide only account administrators with privilege to change a user's username and picture."
+        },
+        "import_photos_from_devices": {
+          "type": "boolean",
+          "description": "Allow users to import photos from a photo library on a  device."
+        },
+        "hide_billing_info": {
+          "type": "boolean",
+          "description": "Hide billing information."
+        }
+      }
+}

--- a/schemas/sharing_details.json
+++ b/schemas/sharing_details.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Sharing details object contains information about the screenshare. ",
+    "type": "object",
+    "properties": {
+        "content": {
+          "type": "string",
+          "description": "The type of content that was shared."
+        },
+        "link_source": {
+          "type": "string",
+          "description": "Represents the method of sharing for dropbox integration.",
+          "enum": [
+            "deep_link",
+            "in_meeting"
+          ]
+        },
+        "file_link": {
+          "type": "string",
+          "description": "The link using which the file was shared via dropbox integration."
+        },
+        "date_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time during which the screenshare happened."
+        }
+      }
+}

--- a/schemas/sharing_details.json
+++ b/schemas/sharing_details.json
@@ -23,6 +23,13 @@
           "type": "string",
           "format": "date-time",
           "description": "The date and time during which the screenshare happened."
+        },
+        "source": {
+          "type": "string",
+          "description": "Source from which the file was shared. ",
+          "enum": [
+            "dropbox"
+          ]
         }
       }
 }

--- a/schemas/telephony_settings.json
+++ b/schemas/telephony_settings.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Telephony settings object.",
+    "type": "object",
+    "properties": {
+        "third_party_audio": {
+          "type": "boolean",
+          "description": "Users can join the meeting using the existing third party audio configuration."
+        },
+        "audio_conference_info": {
+          "type": "string",
+          "description": "Third party audio conference information."
+        }
+      }
+}

--- a/schemas/telephony_settings.json
+++ b/schemas/telephony_settings.json
@@ -10,6 +10,10 @@
         "audio_conference_info": {
           "type": "string",
           "description": "Third party audio conference information."
+        },
+        "show_international_numbers_link": {
+          "type": "boolean",
+          "description": "Show the link for Zoom International Dial-in Numbers on email invitations.\n"
         }
       }
 }

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -7,6 +7,22 @@
           "type": "string",
           "description": "Unique Identifier for a user - User ID"
         },
+        "client_type": {
+          "type": "string",
+          "description": "The Client [type](https://support.zoom.us/hc/en-us/articles/207373866-Zoom-Installers) using which the user signed in.",
+          "enum": [
+            "Browser",
+            "mac",
+            "win",
+            "iphone",
+            "android"
+          ]
+        },
+        "date_time": {
+          "type": "string",
+          "description": "The date and time at which the user signed in.",
+          "format": "date-time"
+        },
         "first_name": {
           "type": "string",
           "description": "First name of the user"
@@ -23,6 +39,10 @@
         "type": {
           "type": "string",
           "description": "User type. <br> `1` - Basic<br>\n`2` - Pro<br> `3` - Corp"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the [Zoom Client](https://support.zoom.us/hc/en-us/articles/207373866-Zoom-Installers). If the user signed in using their browser, the value of this field will be \"-\". "
         }
       }
 }

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "User object",
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique Identifier for a user - User ID"
+        },
+        "first_name": {
+          "type": "string",
+          "description": "First name of the user"
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name of the user"
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the user",
+          "format": "email"
+        },
+        "type": {
+          "type": "string",
+          "description": "User type. <br> `1` - Basic<br>\n`2` - Pro<br> `3` - Corp"
+        }
+      }
+}

--- a/schemas/user_profile.json
+++ b/schemas/user_profile.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Updated user profile object. Only the field that is updated is returned along with the `id`.",
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique Identifier for a user - User ID"
+        },
+        "first_name": {
+          "type": "string",
+          "description": "First name of the user"
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name of the user"
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the user",
+          "format": "email"
+        },
+        "type": {
+          "type": "string",
+          "description": "User type. <br> `1` - Basic<br>\n`2` - Pro<br> `3` - Corp"
+        },
+        "phone_number": {
+          "type": "string",
+          "description": "User's phone number"
+        },
+        "company": {
+          "type": "string",
+          "description": "User's company."
+        },
+        "pmi": {
+          "type": "string",
+          "description": "User's personal meeting Id."
+        },
+        "use_pmi": {
+          "type": "boolean",
+          "description": "User's preference that indicates whether or not they want to use PMI for meetings."
+        },
+        "pic_url": {
+          "type": "string",
+          "description": "URL of the user's profile picture."
+        },
+        "vanity_name": {
+          "type": "string",
+          "description": "Name of the user's personal meeting room."
+        },
+        "host_key": {
+          "type": "string",
+          "description": "Host key",
+          "minLength": 6,
+          "maxLength": 10
+        },
+        "role": {
+          "type": "string",
+          "description": "User's [role](https://support.zoom.us/hc/en-us/articles/115001078646-Role-Based-Access-Control)."
+        },
+        "department": {
+          "type": "string",
+          "description": "User's department."
+        },
+        "settings": { "$ref": "user_profile_settings.json" }
+      }
+}

--- a/schemas/user_profile_settings.json
+++ b/schemas/user_profile_settings.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "User's profile settings. These settings are listed on a [user's profile](https://zoom.us/profile) and are different from [user settings](https://zoom.us/profile/setting).",
+    "type": "object",
+    "properties": {
+        "feature": {
+          "type": "object",
+          "description": "Feature(s) updated on a user's profile.",
+          "properties": {
+            "large_meeting_capacity": {
+              "type": "integer",
+              "description": "The number of meeting participants that are allowed on a per month or yearly basis depending on the [large meeting plan](https://marketplace.zoom.us/docs/api-reference/other-references/plans#largemeetingplans) that is enabled for the user of the account."
+            },
+            "webinar": {
+              "type": "boolean",
+              "description": "Indicates whether or not a webinar plan is enabled for the user."
+            },
+            "webinar_capacity": {
+              "type": "integer",
+              "description": "The number of meeting participants that are allowed on a per month or yearly basis depending on the [webinar plan](https://marketplace.zoom.us/docs/api-reference/other-references/plans#webinar-plans) that is enabled for the user of the account."
+            }
+          }
+        },
+        "meeting_capacity": {
+          "type": "integer",
+          "description": "User's Meeting Capacity"
+        },
+        "large_meeting": {
+          "type": "string",
+          "description": "Indicates whether or not a [large meeting plan](https://marketplace.zoom.us/docs/api-reference/other-references/plans) has been enabled for the user. "
+        }
+      }
+}

--- a/schemas/user_settings.json
+++ b/schemas/user_settings.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Updated settings object. Only the field that is updated is returned along with the `id`.",
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier (User Id) of the user whose settings are updated. "
+        },
+        "settings": {
+          "type": "object",
+          "properties": {
+            "scheduled_meeting": { "$ref": "schedule_meeting.json" },
+            "in_meeting": { "$ref": "in_meeting.json" },
+            "email_notification": { "$ref": "email_notification.json" },
+            "recording": { "$ref": "recording_settings.json" },
+            "telephony": { "$ref": "telephony_settings.json" },
+            "feature": { "$ref": "feature.json" }
+          }
+        }
+      }
+}

--- a/schemas/webinar.json
+++ b/schemas/webinar.json
@@ -1,0 +1,60 @@
+
+
+
+
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Webinar object",
+    "type": "object",
+    "properties": {
+        "id": {
+          "description": "Webinar ID - Unique identifier for a webinar.",
+          "type": "integer"
+        },
+        "uuid": {
+          "type": "string",
+          "description": "Universally Unique Identifier for a Webinar Instance. Each webinar instance will generate its own Webinar UUID."
+        },
+        "host_id": {
+          "type": "string",
+          "description": "ID of the user who is set as the host of the Webinar."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Webinar Topic"
+        },
+        "type": {
+          "type": "string",
+          "description": "Webinar Types:<br> `5` - Webinar<br> `6` - Recurring Webinar without a fixed time<br> `9` - Recurring Webinar with a fixed time. "
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Webinar start time."
+        },
+        "duration": {
+          "type": "string",
+          "description": "Meeting duration."
+        },
+        "participant": { "$ref": "participant.json" },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone for the Webinar."
+        },
+        "password": {
+          "type": "string",
+          "description": "Webinar Password"
+        },
+        "agenda": {
+          "type": "string",
+          "description": "Webinar agenda."
+        },
+        "occurrences": { "$ref": "occurences.json" },
+        "recurrence": { "$ref": "recurrence.json" },
+        "settings": { "$ref": "webinar_settings.json" },
+        "registration_url": {
+          "type": "string",
+          "description": "Registration URL of the Webinar."
+        },
+        "registrant": { "$ref": "registrant.json" }
+    }
+}

--- a/schemas/webinar_settings.json
+++ b/schemas/webinar_settings.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Webinar Settings",
+    "type": "object",
+    "properties": {
+        "host_video": {
+          "description": "Turn the video setting on for the host when the host joins the Webinar.",
+          "type": "boolean"
+        },
+        "panelists_video": {
+          "description": "Turn panelists' video on when they join the webinar.",
+          "type": "boolean"
+        },
+        "practice_session": {
+          "description": "Enable [practice session](https://support.zoom.us/hc/en-us/articles/206316975-Webinar-Practice-Session).",
+          "type": "boolean"
+        },
+        "approval_type": {
+          "description": "Approval type for the webinar registrants. <br>\n`0` - Automatically approve.<br> `1` - Manually approve. <br> `2` No registration required.",
+          "type": "integer"
+        },
+        "registration_type": {
+          "type": "integer",
+          "description": "Registration setting for recurring Webinars.\n<br>`1` - Attendees register once and can attend any of the occurrences.<br>`2` -  Attendees need to register for each occurrence to attend.<br>`3` -  Attendees register once and can choose one or more occurrences to attend."
+        },
+        "audio": {
+          "type": "string",
+          "description": "Determine how participants can join the audio portion of the meeting.<br>`both` - Both Telephony and VoIP.<br>`telephony` - Telephony only.<br>`voip` - VoIP only."
+        },
+        "auto_recording": {
+          "type": "string",
+          "description": "Automatic recording setting for the Webinar:<br>`local` - Record and store on the local device.<br>`cloud` -  Record and store on Cloud.<br>`none` - Automatic Recording Disabled."
+        },
+        "enforce_login": {
+          "type": "string",
+          "description": "Enable only signed in users to join this meeting."
+        }
+      }
+}

--- a/schemas/zoom_rooms.json
+++ b/schemas/zoom_rooms.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Zoom Rooms settings object",
+    "type": "object",
+    "properties": {
+        "upcoming_meeting_alert": {
+          "type": "boolean",
+          "description": "Upcoming meeting alert."
+        },
+        "start_airplay_manually": {
+          "type": "boolean",
+          "description": "Start AirPlay service manually."
+        },
+        "weekly_system_restart": {
+          "type": "boolean",
+          "description": "Weekly system restart."
+        },
+        "list_meetings_with_calendar": {
+          "type": "boolean",
+          "description": "Display meeting list with calendar integration."
+        },
+        "zr_post_meeting_feedback": {
+          "type": "boolean",
+          "description": "Zoom Room post meeting feedback."
+        },
+        "ultrasonic": {
+          "type": "boolean",
+          "description": "Automatic direct sharing using  an ultrasonic proximity signal."
+        },
+        "force_private_meeting": {
+          "type": "boolean",
+          "description": "Transform all meetings to [private](https://support.zoom.us/hc/en-us/articles/115001051063-Zoom-Rooms-Private-Meetings)."
+        },
+        "hide_host_information": {
+          "type": "boolean",
+          "description": "Hide host and meeting ID from private meetings."
+        },
+        "cmr_for_instant_meeting": {
+          "type": "boolean",
+          "description": "Enable cloud recording for instant meetings."
+        },
+        "auto_start_stop_scheduled_meetings": {
+          "type": "boolean",
+          "description": "Set automatic start and stop for scheduled meetings."
+        }
+      }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -89,6 +89,8 @@ provider:
     # We could also store this in SSM
     SQS_URL:
       Ref: ResourceQueue
+    TQ_URL:
+      Ref: TransientQueue
 
 package:
   # This is to keep the package to be uploaded as small as possible in size

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,6 +64,8 @@ provider:
         - sqs:TagQueue
       Resource: 
         - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.project}-${self:service}-${self:provider.stage}"
+        - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.project}-${self:service}-${self:provider.stage}-TQ"
+        - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.project}-${self:service}-${self:provider.stage}-DLQ"
     - Effect: Allow
       Action: 
         - ssm:GetParameter
@@ -104,7 +106,7 @@ functions:
   customAuthorizer: 
     handler: functions/authorizer.validate_token
   eventHandler:
-    handler: functions/handler.lambda_handler
+    handler: functions/handler.event_handler
     description: Lambda for handling events from ${self:service} resource.
     events:
       - http:
@@ -112,7 +114,14 @@ functions:
           method: ${self:custom.cfg.api_method}
           cors: true
           authorizer: ${self:custom.authorizer.validate_token}
-
+  schemaValidator:
+    handler: functions/handler.validate_event
+    description: Lambda for validating events from ${self:service} resource.
+    events:
+      - sqs:
+          arn:
+            Fn::GetAtt: [ TransientQueue, Arn ]
+          batchSize: 1
 resources:
   Resources:
     ResourceQueue:    
@@ -130,6 +139,19 @@ resources:
         Tags:
         - Key: "Project"
           Value: ${self:custom.cfg.project}-${self:provider.stage}
+    TransientQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}-TQ
+        VisibilityTimeout: 60
+        MessageRetentionPeriod: 604800
+        # We should probably make this queue use the DLQ instead
+        # RedrivePolicy:
+        #   deadLetterTargetArn:
+        #     "Fn::GetAtt":
+        #       - ReceiverDeadLetterQueue
+        #       - Arn
+        #   maxReceiveCount: 2
     DeadLetterQueue:
       Type: AWS::SQS::Queue
       Properties:


### PR DESCRIPTION
Using another lambda and another queue.

The aim of this PR is to:
- Make acceptance of incoming events (almost) async - basically perform a very trivial validation on the REST API, and if valid, add it to a transient queue
- Using another lambda function, read the transient queue, and perform a better/proper validation on the incoming events
- If valid, pass it to the **real** queue, which is used by the MozDef worker.

In an ideal world, the non-comforming/invalid messages in the transient queue would be passed to a DLQ for handling. This is to be explored in the future (and in another PR).