### PR TITLE
[WIP] Implement monitoring and alerting using CloudWatch logs

### DIFF
--- a/functions/authorizer.py
+++ b/functions/authorizer.py
@@ -12,8 +12,6 @@ from aws_xray_sdk.core import patch_all
 REGION = os.getenv('REGION', 'us-west-2')
 ssm = boto3.client('ssm', region_name=REGION)
 service_token = os.getenv('TOKEN')
-# logger = logging.getLogger()
-# logger.setLevel(logging.INFO)
 
 patch_all()
 

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -13,8 +13,6 @@ REGION = os.getenv('REGION', 'us-west-2')
 service = os.getenv('SERVICE', 'default')
 sqs = boto3.client('sqs', region_name=REGION)
 ssm = boto3.client('ssm', region_name=REGION)
-# logger = logging.getLogger()
-# logger.setLevel(logging.INFO)
 
 patch_all()
 

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -71,9 +71,8 @@ def lambda_handler(event, context, sqs_client = boto3.client('sqs', region_name=
     }
 
 def logs_handler(event, context):
-    print(event)
+    # print(event)
     cw_data = event['awslogs']['data']
-    print(cw_data)
 
     compressed_payload = base64.b64decode(cw_data)
     uncompressed = gzip.decompress(compressed_payload)
@@ -89,13 +88,9 @@ def subscribe_to_logs_handler(event, context):
     print(event)
     # Need to wrap this in try - except
     logGroupName = event['detail']['requestParameters']['logGroupName']
-    # print(logGroupName)
+    print(logGroupName)
 
-    if prefix and prefix not in logGroupName:
-        pass
-        # logger.warning("ignoring the log group {}, because it does not match the prefix {}".format(logGroupName, prefix))
-    else:
-        print(logGroupName)
+    if prefix and prefix in logGroupName:
         subscribe(logGroupName)
         logger.info("Subscribed {} to {}".format(logGroupName, log_handler))
 
@@ -104,5 +99,5 @@ def subscribe(log_group_name):
        destinationArn=log_handler,
        logGroupName=log_group_name,
        filterName='ship-logs-to-SQS',
-       filterPattern='*',
+       filterPattern='',
     )

--- a/functions/log_handler.py
+++ b/functions/log_handler.py
@@ -15,7 +15,9 @@ REGION = os.getenv('REGION', 'us-west-2')
 service = os.getenv('SERVICE', 'default')
 prefix = os.getenv('LOG_HANDLER_PREFIX', '/aws/lambda')
 log_handler = os.getenv('LOG_HANDLER_FUNCTION', 'default')
+log_handler_arn = os.getenv('LOG_HANDLER_FUNCTION_ARN', 'default')
 cw_logs = boto3.client('logs')
+sqs = boto3.client('sqs', region_name=REGION)
 # logger = logging.getLogger()
 # logger.setLevel(logging.INFO)
 
@@ -35,8 +37,10 @@ def setup_logging():
     logging.getLogger("botocore").setLevel(logging.WARNING)
     return logger
 
-def handler(event, context):
+def handler(event, context, sqs_client = boto3.client('sqs', region_name=REGION), sqs_url=os.getenv('LOGS_SQS_URL')):
     logger = setup_logging()
+    queueURL = sqs_url
+
     try:
         cw_data = event['awslogs']['data']
         compressed_payload = base64.b64decode(cw_data)
@@ -48,22 +52,29 @@ def handler(event, context):
     # or maybe an S3 bucket?
     log_events = payload['logEvents']
     for log_event in log_events:
-        print(log_event)
+        sqs_client.send_message(QueueUrl=queueURL, MessageBody=log_event['message'].strip('\n'))
+    
+    logger.info("Log messages added to the logs queue.")
 
 def subscribe_to_log_handler(event, context, cw_logs_client=boto3.client('logs')):
     logger = setup_logging()
-    print(event)
+    suffix = log_handler
     try:
         log_group_name = event['detail']['requestParameters']['logGroupName']
-    except Exception as e:
-        logger.warning("An unexpected CloudTrail event received, exception: {}".format(e))
-    # print(log_group_name)
+        # Cannot subscribe logs for the same function to itself, so ignoring suffix
+        # We only want to subscribe to logs that are WARNING or ERROR level
+        if prefix and suffix and prefix in log_group_name and suffix not in log_group_name:
+            try:
+                cw_logs_client.put_subscription_filter(
+                    destinationArn=log_handler_arn,
+                    logGroupName=log_group_name,
+                    filterName='ship-logs-to-SQS',
+                    filterPattern='{ $.levelname = "WARNING" || $.levelname = "ERROR" }'
+                )
+            except Exception as e:
+                logger.warning("Failed to subscribe log group {}, exception: {}".format(log_group_name, e))
+            logger.info("Subscribed {} to {}".format(log_group_name, log_handler_arn))
 
-    if prefix and prefix in log_group_name:
-        cw_logs.put_subscription_filter(
-           destinationArn=log_handler,
-           logGroupName=log_group_name,
-           filterName='ship-logs-to-SQS',
-           filterPattern='',
-        )
-        logger.info("Subscribed {} to {}".format(log_group_name, log_handler))
+    except Exception as e:
+        # We do not care about events that has a missing log group name
+        pass

--- a/functions/log_handler.py
+++ b/functions/log_handler.py
@@ -1,0 +1,69 @@
+import boto3
+import json
+import logging
+import os
+import sys
+import socket
+import gzip
+import base64
+import cis_logger    # Custom module
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core import patch_all
+
+
+REGION = os.getenv('REGION', 'us-west-2')
+service = os.getenv('SERVICE', 'default')
+prefix = os.getenv('LOG_HANDLER_PREFIX', '/aws/lambda')
+log_handler = os.getenv('LOG_HANDLER_FUNCTION', 'default')
+cw_logs = boto3.client('logs')
+# logger = logging.getLogger()
+# logger.setLevel(logging.INFO)
+
+patch_all()
+
+
+def setup_logging():
+    logger = logging.getLogger()
+    for h in logger.handlers:
+        logger.removeHandler(h)
+    h = logging.StreamHandler(sys.stdout)
+    h.setFormatter(cis_logger.JsonFormatter(extra={"hostname": socket.gethostname()}))
+    logger.addHandler(h)
+    logger.setLevel(logging.INFO)
+
+    # Quiet botocore verbose logging...
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    return logger
+
+def handler(event, context):
+    logger = setup_logging()
+    try:
+        cw_data = event['awslogs']['data']
+        compressed_payload = base64.b64decode(cw_data)
+        uncompressed = gzip.decompress(compressed_payload)
+        payload = json.loads(uncompressed)
+    except Exception as e:
+        logger.error("Cannot parse CloudWatch log event, exception: {}".format(e))
+    # This is where we would send to SQS instead
+    # or maybe an S3 bucket?
+    log_events = payload['logEvents']
+    for log_event in log_events:
+        print(log_event)
+
+def subscribe_to_log_handler(event, context, cw_logs_client=boto3.client('logs')):
+    logger = setup_logging()
+    print(event)
+    try:
+        log_group_name = event['detail']['requestParameters']['logGroupName']
+    except Exception as e:
+        logger.warning("An unexpected CloudTrail event received, exception: {}".format(e))
+    # print(log_group_name)
+
+    if prefix and prefix in log_group_name:
+        cw_logs.put_subscription_filter(
+           destinationArn=log_handler,
+           logGroupName=log_group_name,
+           filterName='ship-logs-to-SQS',
+           filterPattern='',
+        )
+        logger.info("Subscribed {} to {}".format(log_group_name, log_handler))

--- a/functions/log_handler.py
+++ b/functions/log_handler.py
@@ -18,8 +18,6 @@ log_handler = os.getenv('LOG_HANDLER_FUNCTION', 'default')
 log_handler_arn = os.getenv('LOG_HANDLER_FUNCTION_ARN', 'default')
 cw_logs = boto3.client('logs')
 sqs = boto3.client('sqs', region_name=REGION)
-# logger = logging.getLogger()
-# logger.setLevel(logging.INFO)
 
 patch_all()
 
@@ -71,10 +69,12 @@ def subscribe_to_log_handler(event, context, cw_logs_client=boto3.client('logs')
                     filterName='ship-logs-to-SQS',
                     filterPattern='{ $.levelname = "WARNING" || $.levelname = "ERROR" }'
                 )
+                logger.info("Subscribed {} to {}".format(log_group_name, log_handler_arn))
+                return True
             except Exception as e:
                 logger.warning("Failed to subscribe log group {}, exception: {}".format(log_group_name, e))
-            logger.info("Subscribed {} to {}".format(log_group_name, log_handler_arn))
+                return False
 
     except Exception as e:
         # We do not care about events that has a missing log group name
-        pass
+        return False

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/mozilla/mozdef-event-framework#readme",
   "devDependencies": {
     "serverless-prune-plugin": "^1.4.1",
-    "serverless-pseudo-parameters": "^2.4.0"
+    "serverless-pseudo-parameters": "^2.4.0",
+    "serverless-python-requirements": "^5.0.1"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytest==4.6.2
+boto3==1.9.165
+moto==1.3.8
+aws_xray_sdk==0.95
+file:vendor/cis_logger

--- a/serverless.yml
+++ b/serverless.yml
@@ -70,6 +70,7 @@ provider:
         - sqs:TagQueue
       Resource: 
         - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.project}-${self:service}-${self:provider.stage}"
+        - "arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${self:custom.cfg.project}-${self:service}-${self:provider.stage}-CWLogs"
     - Effect: Allow
       Action: 
         - ssm:GetParameter
@@ -133,9 +134,19 @@ resources:
             - ""
             - - "Ref" : "ShipLogsToSQSLambdaFunction"
         Principal: logs.#{AWS::Region}.amazonaws.com
-    ResourceQueue:    
+    LogsQueue:
       Type: AWS::SQS::Queue
       Properties:
+        QueueName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}-CWLogs
+        # The below values should be tuned
+        MessageRetentionPeriod: 1209600
+        VisibilityTimeout: 60
+        Tags:
+        - Key: "Project"
+          Value: ${self:custom.cfg.project}-${self:provider.stage}
+    ResourceQueue:
+      Type: AWS::SQS::Queue
+      Properties: 
         QueueName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}
         MessageRetentionPeriod: 1209600
         VisibilityTimeout: 60

--- a/serverless.yml
+++ b/serverless.yml
@@ -107,6 +107,9 @@ package:
     - tests/**
 
 functions:
+  shipLogsToSQS:
+    handler: functions/handler.logs_handler
+    description: Sends CloudWatch logs to an SQS queue for MozDef consumption.
   customAuthorizer: 
     handler: functions/authorizer.validate_token
   eventHandler:
@@ -121,6 +124,15 @@ functions:
 
 resources:
   Resources:
+    LambdaInvokePermission:
+      Type: AWS::Lambda::Permission
+      Properties:
+        Action: lambda:InvokeFunction
+        FunctionName:
+          Fn::Join:
+            - ""
+            - - "Ref" : "ShipLogsToSQSLambdaFunction"
+        Principal: logs.#{AWS::Region}.amazonaws.com
     ResourceQueue:    
       Type: AWS::SQS::Queue
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -118,12 +118,12 @@ package:
 
 functions:
   subscribeLogs:
-    handler: functions/handler.subscribe_to_logs_handler
+    handler: functions/log_handler.subscribe_to_log_handler
     description: Subscribe logs to "shipLogsToSQS" function.
     environment:
       LOG_HANDLER_FUNCTION: '#{ShipLogsToSQSLambdaFunction.Arn}'
-      LOG_HANDLER_PREFIX: "/aws/lambda/${self:service}-${env:STAGE}-eventHandler"
-      LOG_HANDLER_ROLE: '#{IamRoleLambdaExecution.Arn}'
+      # TODO: Need to find a way to exclude the logs of shipLogsToSQS lambda to itself
+      LOG_HANDLER_PREFIX: '/aws/lambda/${self:service}-${env:STAGE}'
     events:
       - cloudwatchEvent:
           event:
@@ -136,9 +136,8 @@ functions:
                 - logs.amazonaws.com
               eventName:
                 - CreateLogGroup
-                # - CreateLogStream
   shipLogsToSQS:
-    handler: functions/handler.logs_handler
+    handler: functions/log_handler.handler
     description: Sends CloudWatch logs to an SQS queue for MozDef consumption.
   customAuthorizer: 
     handler: functions/authorizer.validate_token

--- a/serverless.yml
+++ b/serverless.yml
@@ -43,7 +43,7 @@ custom:
     useDownloadCache: false
     useStaticCache: false
     dockerizePip: true
-    dockerRunCmdExtraArgs: ["-v", "${env:PWD}/mozilla/cis_logger:/var/task/vendor/mozilla/cis_logger"]
+    dockerRunCmdExtraArgs: ["-v", "${env:PWD}/vendor/cis_logger:/var/task/vendor/cis_logger"]
     
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,10 +14,9 @@
 
 service: ${env:SERVICE}
 plugins:
-# Removing the serverless-stack-output plugin, as I do not think
-# we need it, but I may be wrong
   - serverless-prune-plugin
   - serverless-pseudo-parameters
+  - serverless-python-requirements
 custom:
   authorizer:
     validate_token:
@@ -40,6 +39,8 @@ custom:
   prune:
     automatic: true
     number: ${self:custom.cfg.keep}
+  pythonRequirements:
+    dockerizePip: true
 
 provider:
   name: aws
@@ -55,6 +56,14 @@ provider:
   stackName: ${self:service}-${self:provider.stage}
   apiName: ${self:custom.cfg.project}-${self:service}-${self:provider.stage}
   iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - "logs:PutSubscriptionFilter"
+      Resource: "*"
+    - Effect: "Allow"
+      Action:
+        - "iam:PassRole"
+      Resource: "*"
     - Effect: Allow
       Action:
         - xray:PutTraceSegments
@@ -108,6 +117,25 @@ package:
     - tests/**
 
 functions:
+  subscribeLogs:
+    handler: functions/handler.subscribe_to_logs_handler
+    description: Subscribe logs to "shipLogsToSQS" function.
+    environment:
+      LOG_HANDLER_FUNCTION: '#{ShipLogsToSQSLambdaFunction.Arn}'
+      LOG_HANDLER_PREFIX: "/aws/lambda/${self:service}-${env:STAGE}"
+      LOG_HANDLER_ROLE: '#{IamRoleLambdaExecution.Arn}'
+    events:
+      - cloudwatchEvent:
+          event:
+            source:
+              - aws.logs
+            detail-type:
+              - AWS API Call via CloudTrail
+            detail:
+              eventSource:
+                - logs.amazonaws.com
+              eventName:
+                - CreateLogGroup
   shipLogsToSQS:
     handler: functions/handler.logs_handler
     description: Sends CloudWatch logs to an SQS queue for MozDef consumption.

--- a/serverless.yml
+++ b/serverless.yml
@@ -122,7 +122,7 @@ functions:
     description: Subscribe logs to "shipLogsToSQS" function.
     environment:
       LOG_HANDLER_FUNCTION: '#{ShipLogsToSQSLambdaFunction.Arn}'
-      LOG_HANDLER_PREFIX: "/aws/lambda/${self:service}-${env:STAGE}"
+      LOG_HANDLER_PREFIX: "/aws/lambda/${self:service}-${env:STAGE}-eventHandler"
       LOG_HANDLER_ROLE: '#{IamRoleLambdaExecution.Arn}'
     events:
       - cloudwatchEvent:
@@ -136,6 +136,7 @@ functions:
                 - logs.amazonaws.com
               eventName:
                 - CreateLogGroup
+                # - CreateLogStream
   shipLogsToSQS:
     handler: functions/handler.logs_handler
     description: Sends CloudWatch logs to an SQS queue for MozDef consumption.
@@ -157,10 +158,7 @@ resources:
       Type: AWS::Lambda::Permission
       Properties:
         Action: lambda:InvokeFunction
-        FunctionName:
-          Fn::Join:
-            - ""
-            - - "Ref" : "ShipLogsToSQSLambdaFunction"
+        FunctionName: '#{ShipLogsToSQSLambdaFunction}'
         Principal: logs.#{AWS::Region}.amazonaws.com
     LogsQueue:
       Type: AWS::SQS::Queue

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,8 +40,11 @@ custom:
     automatic: true
     number: ${self:custom.cfg.keep}
   pythonRequirements:
+    useDownloadCache: false
+    useStaticCache: false
     dockerizePip: true
-
+    dockerRunCmdExtraArgs: ["-v", "${env:PWD}/mozilla/cis_logger:/var/task/vendor/mozilla/cis_logger"]
+    
 provider:
   name: aws
   runtime: python3.7
@@ -101,8 +104,10 @@ provider:
     TOKEN: "/${self:custom.cfg.project}/${self:custom.cfg.authToken}"
     # Adding resource queue URL as global environment variable
     # We could also store this in SSM
-    SQS_URL:
+    EVENT_SQS_URL:
       Ref: ResourceQueue
+    LOGS_SQS_URL:
+      Ref: LogsQueue
 
 package:
   # This is to keep the package to be uploaded as small as possible in size
@@ -121,8 +126,9 @@ functions:
     handler: functions/log_handler.subscribe_to_log_handler
     description: Subscribe logs to "shipLogsToSQS" function.
     environment:
-      LOG_HANDLER_FUNCTION: '#{ShipLogsToSQSLambdaFunction.Arn}'
-      # TODO: Need to find a way to exclude the logs of shipLogsToSQS lambda to itself
+      # Env vars local to this function only
+      LOG_HANDLER_FUNCTION: '#{ShipLogsToSQSLambdaFunction}'
+      LOG_HANDLER_FUNCTION_ARN: '#{ShipLogsToSQSLambdaFunction.Arn}'
       LOG_HANDLER_PREFIX: '/aws/lambda/${self:service}-${env:STAGE}'
     events:
       - cloudwatchEvent:
@@ -136,6 +142,7 @@ functions:
                 - logs.amazonaws.com
               eventName:
                 - CreateLogGroup
+                - CreateLogStream
   shipLogsToSQS:
     handler: functions/log_handler.handler
     description: Sends CloudWatch logs to an SQS queue for MozDef consumption.

--- a/tests/unit-tests/test_log_handler.py
+++ b/tests/unit-tests/test_log_handler.py
@@ -1,0 +1,123 @@
+import json
+import pytest
+import boto3
+import os
+import time
+from moto import mock_sqs, mock_logs
+
+
+@pytest.fixture(scope='function')
+def aws_credentials():
+    # Mocked AWS Credentials for moto, this is required 
+    # as per their readme: https://github.com/spulec/moto
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+
+    # Disable X-Ray for unit tests
+    from aws_xray_sdk import global_sdk_config
+    global_sdk_config.set_sdk_enabled(False)
+
+@pytest.fixture(scope='function')
+def sqs(aws_credentials):
+    mock = mock_sqs()
+    mock.start()
+
+    sqs_client = boto3.client('sqs', 'us-west-2')
+    queue_name = "test-logs-queue"
+    queue_url = sqs_client.create_queue(
+        QueueName=queue_name
+    )['QueueUrl']
+
+    yield (sqs_client, queue_url)
+    mock.stop()
+
+@pytest.fixture(scope='function')
+def logs(aws_credentials):
+    mock = mock_logs()
+    mock.start()
+
+    logs_client = boto3.client('logs')
+
+    yield logs_client
+    mock.stop()
+
+def test_handler(sqs):
+    sqs_client, queue_url = sqs
+    test_cwlog = {
+        "awslogs": {
+            "data": "H4sIABy01F0C/52Tb2vbMBDGv4oRe7cmkSzLlvMusLQU2jCWwGB1CYp9a8Ucy8hKui7ku1fnP02ywRgzBqN7Ht2d7icfyBaaRj3B6rUGMg3Ip9lqtr6fL5ezmzm5Coh5qcCikJ49KJTm6caaXY3aRL00k1JtN4WaOGjcqAG71zn0vqWzoLZoDClLJ1ROwnjy8OFutpovV4+FUCqKNrFKQUbAZLoJVb5JOFAuUx6GmKTZbZrc6tppU13r0oFtfLoHctfW7PKvsfL6e6uSx67yfA+Va60HogvsgHPBRSQjkYZciCgSsX9DEScx45JGkeQ0pqnkMqLemYRUSBGFVGIXTvthObXFMzNBeSI540lKU6/1Y8QSh4yoJkdz5pdZe+gRY6OQriidMj4V9NtH6p/MJ81IpQajNcZ1sdqa3CdcvEv3Slefu2Dn8OeE0061c8/G6l9gx/Vrb9hV+Wn/XpW6UA7WzvyAqnOUsIfylOPr7MvidnHTa7qCyqAgE1xvTbEr/yjWed2zH39x2euqjXV6P5pOvK1yYy3kLhjSKIQatH0FXgC9h+IqKKypa109BYAIx32lAcA/DfbZNO50PBan41BEY8b8N83IMauQKfx0VuUOimsNZYFX5TDQGy7sqYSQU8G6ErgXk6MJueH6jBqGz5ihOhBD6YJXK/a0ULxk1f5DAymUe05tvKXUQ+oZXaZvr+07n6Grjg65vLb/Seb3H+PvIxuYoHEgwtlYCnI8Ph7fAFefEKmOBAAA"
+        }
+    }
+    from functions import log_handler
+    # This function does not return anything, wait before checking queue
+    log_handler.handler(test_cwlog, "", sqs_client, queue_url)
+    time.sleep(2)
+    # Now check our queue content
+    response = sqs_client.receive_message(QueueUrl=queue_url)
+    log_message = response['Messages'][0]['Body']
+    assert type(log_message) is str
+    log_message_dict = json.loads(log_message)
+    assert 'asctime' in log_message_dict
+    assert 'name' in log_message_dict
+    assert 'processName' in log_message_dict
+    assert 'filename' in log_message_dict
+    assert 'funcName' in log_message_dict
+    assert 'levelname' in log_message_dict
+    assert 'lineno' in log_message_dict
+    assert 'module' in log_message_dict
+    assert 'threadName' in log_message_dict
+    assert 'message' in log_message_dict
+    assert 'timestamp' in log_message_dict
+    assert 'hostname' in log_message_dict
+
+def test_subscribe_to_log_handler(logs):
+    logs_client = logs
+    test_cloudtrail_cw_event = {
+        "version": "0",
+        "id": "52d15c46-1bbc-47da-84e4-cef8c4dfc5b7",
+        "detail-type": "AWS API Call via CloudTrail",
+        "source": "aws.logs",
+        "account": "TEST",
+        "time": "2019-08-20T18:50:54Z",
+        "region": "us-west-2",
+        "resources": [],
+        "detail": {
+            "eventVersion": "1.04",
+            "userIdentity": {
+                "type": "IAMUser",
+                "principalId": "AIDAIP5G4Z37ZNNNKVEUW",
+                "arn": "arn:aws:iam::xxx:user/test",
+                "accountId": "TEST",
+                "accessKeyId": "TEST",
+                "userName": "test",
+                "sessionContext": {
+                    "attributes": {
+                        "mfaAuthenticated": "false",
+                        "creationDate": "2017-08-20T18:50:48Z"
+                    }
+                },
+                "invokedBy": "cloudformation.amazonaws.com"
+            },
+        "eventTime": "2017-08-20T18:50:54Z",
+        "eventSource": "logs.amazonaws.com",
+        "eventName": "CreateLogGroup",
+        "awsRegion": "us-west-2",
+        "sourceIPAddress": "cloudformation.amazonaws.com",
+        "userAgent": "cloudformation.amazonaws.com",
+        "requestParameters": {
+            "logGroupName": "/aws/lambda/test-service"
+        },
+        "responseElements": None,
+        "requestID": "7f14f744-85d8-11e7-b277-a3957840b2c0",
+        "eventID": "ddcd560b-b39e-4991-8e2b-e39fd8d7dabf",
+        "eventType": "AwsApiCall",
+        "apiVersion": "20140328"
+        }
+    }
+    from functions import log_handler
+    response = log_handler.subscribe_to_log_handler(test_cloudtrail_cw_event, "", logs_client)
+    # NOTE: This SHOULD return True, however at the moment moto cannot mock
+    # the CloudWatch "subscribe_to_log_handler" API, therefore expecting False
+    assert response is False

--- a/vendor/cis_logger/Makefile
+++ b/vendor/cis_logger/Makefile
@@ -1,0 +1,63 @@
+ROOT_DIR        := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+MODULE_NAME     := $(notdir $(patsubst %/,%,$(ROOT_DIR)))
+SHELL		:= /bin/bash
+
+all:
+	@echo 'Available make targets:'
+	@grep '^[^#[:space:]].*:' Makefile
+
+install:
+	# Installs as egg
+	python3 setup.py install
+	# Installs via pip
+	pip install .
+
+build:
+	python3 setup.py build
+
+upload:
+	python3 setup.py sdist check upload --sign
+
+python-venv: venv
+venv:
+	$(shell [ -d venv ] || python3 -m venv venv)
+	echo "# Run this in your shell to activate:"
+	echo "source venv/bin/activate"
+
+.install-test:
+		pip install .[test]
+		npm install kinesalite
+		touch $@
+
+.flake:
+	flake8 setup.py
+	flake8 tests/*.py
+	flake8 $(MODULE_NAME)/*.py
+
+watch-test:
+	# Watches for changes and re-test automatically
+	# we use this wrapper because our test target allows for more tests
+	# than ptw's builting pytest, notably flake8 tests
+	ptw --runner "make test"
+
+test: tests
+tests: .install-test .flake
+	PATH=$(PATH):$(shell npm bin) \
+	python3 setup.py test
+
+.PHONY test-tox:
+test-tox: .flake
+	PATH=$(PATH):$(shell npm bin) \
+	tox -p all --parallel-live
+
+clean:
+	rm -rf venv
+	rm -rf __pycache__
+	rm -rf *.egg-info
+	rm -rf .eggs
+	rm -rf build
+	rm -rf dist
+	rm -rf .install-test
+	rm -rf node_modules
+
+.PHONY: test tests clean all install

--- a/vendor/cis_logger/README.md
+++ b/vendor/cis_logger/README.md
@@ -1,0 +1,3 @@
+# cis_logger
+
+Unify logs out of mozilla iam change integration service and store them in a format consumable by MozDef.

--- a/vendor/cis_logger/cis_logger/__init__.py
+++ b/vendor/cis_logger/cis_logger/__init__.py
@@ -1,0 +1,46 @@
+import logging.handlers
+from pythonjsonlogger import jsonlogger
+import datetime
+
+
+class JsonFormatter(jsonlogger.JsonFormatter, object):
+    def __init__(
+        self,
+        fmt="%(asctime) %(name) %(processName) %(filename) \
+        %(funcName) %(levelname) %(lineno) %(module) %(threadName) %(message)",
+        datefmt="%Y-%m-%dT%H:%M:%SZ%z",
+        style="%",
+        extra={},
+        *args,
+        **kwargs
+    ):
+        self._extra = extra
+        jsonlogger.JsonFormatter.__init__(self, fmt=fmt, datefmt=datefmt, *args, **kwargs)
+
+    def process_log_record(self, log_record):
+        if "asctime" in log_record:
+            log_record["timestamp"] = log_record["asctime"]
+        else:
+            log_record["timestamp"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ%z")
+
+        if self._extra is not None:
+            for key, value in self._extra.items():
+                log_record[key] = value
+        return super(JsonFormatter, self).process_log_record(log_record)
+
+
+class SysLogJsonHandler(logging.handlers.SysLogHandler, object):
+    def __init__(
+        self,
+        address=("localhost", logging.handlers.SYSLOG_UDP_PORT),
+        facility=logging.handlers.SysLogHandler.LOG_USER,
+        socktype=None,
+        prefix="",
+    ):
+        super(SysLogJsonHandler, self).__init__(address, facility, socktype)
+        self._prefix = prefix
+        if self._prefix != "":
+            self._prefix = prefix + ": "
+
+    def format(self, record):
+        return self._prefix + super(SysLogJsonHandler, self).format(record)

--- a/vendor/cis_logger/pytest.ini
+++ b/vendor/cis_logger/pytest.ini
@@ -1,0 +1,13 @@
+# pytest.ini
+
+[pytest]
+addopts = --maxfail=6
+norecursedirs = docs *.egg-info .git appdir .tox venv env
+
+filterwarnings =
+   ignore::FutureWarning
+   ignore::DeprecationWarning
+
+[pytest-watch]
+ignore = ./integration-tests
+nobeep = True

--- a/vendor/cis_logger/setup.cfg
+++ b/vendor/cis_logger/setup.cfg
@@ -1,0 +1,19 @@
+[bumpversion]
+current_version = 0.3.8
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bdist_wheel]
+universal = 1
+
+[flake8]
+exclude = docs
+max-line-length = 120
+ignore=E266,W503
+
+[aliases]
+test=pytest

--- a/vendor/cis_logger/setup.py
+++ b/vendor/cis_logger/setup.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+requirements = ["python-json-logger", "everett", "everett[ini]"]
+test_requirements = ["pytest", "pytest-watch", "pytest-cov", "flake8", "flask", "flask_graphql", "flask_restful"]
+setup_requirements = ["pytest-runner", "setuptools>=40.5.0"]
+
+extras = {"test": test_requirements}
+
+setup(
+    name="cis_logger",
+    version="0.0.1",
+    author="Andrew Krug",
+    author_email="akrug@mozilla.com",
+    description="Mozilla IAM logger wrapper.",
+    long_description=long_description,
+    url="https://github.com/mozilla-iam/cis",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=requirements,
+    license="Mozilla Public License 2.0",
+    include_package_data=True,
+    packages=find_packages(include=["cis_logger"]),
+    setup_requires=setup_requirements,
+    tests_require=test_requirements,
+    extras_require=extras,
+    test_suite="tests",
+    zip_safe=True,
+)

--- a/vendor/cis_logger/tests/test_log.py
+++ b/vendor/cis_logger/tests/test_log.py
@@ -1,0 +1,28 @@
+import logging
+import socket
+
+import cis_logger
+
+
+class TestLogger(object):
+    def setup_class(self):
+        self.logger = logging.getLogger()
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(cis_logger.JsonFormatter(extra={"hello": "world", "hostname": socket.gethostname()}))
+
+        self.logger.addHandler(handler)
+        self.logger.setLevel(logging.INFO)
+
+    def test_logger(self):
+        test_logger = logging.getLogger("test")
+        test_logger.info({"special": "value", "run": 12})
+        test_logger.info("classic message", extra={"special": "value", "run": 12})
+
+    def test_an_exception(self):
+        test_logger = logging.getLogger("test")
+
+        try:
+            raise Exception("test")
+        except Exception:
+            test_logger.exception("This is a fake exception")

--- a/vendor/cis_logger/tox.ini
+++ b/vendor/cis_logger/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+minversion = 3.5.0
+envlist = py3
+skipsdist=True
+
+[testenv]
+envdir = {toxinidir}/../.cis-env/cis_logger
+
+deps=
+  .[test]
+commands=pytest tests/ --cov=cis_logger {posargs}


### PR DESCRIPTION
While #18 implements monitoring via X-Ray, it does not provide a facility to alert when problems raise.

In this PR, I will explore a way to alert based on consumption of CloudWatch alerts. This will involve having a lambda monitoring and collecting CW logs, doing some processing and placing them on an SQS queue. The idea is to have MozDef consume that queue, and create (non-security based) alerting on MozDef.

Note: This does not mean the work in #18 is useless, we can both have X-Ray monitoring and this if we like.